### PR TITLE
Feature/invoiced atoms

### DIFF
--- a/apps/api/expenses/serializers.py
+++ b/apps/api/expenses/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from apps.expenses.models import Expense
 from apps.jobs.models import Job
+from apps.api.mixins import InvoiceRefMixin
 
 
 class NewMaterialSerializer(serializers.Serializer):
@@ -20,14 +21,15 @@ class NewMaterialSerializer(serializers.Serializer):
     )
 
 
-class ExpenseSerializer(serializers.ModelSerializer):
+class ExpenseSerializer(InvoiceRefMixin, serializers.ModelSerializer):
+    invoice_source_type = 'expense'
+    invoice = serializers.SerializerMethodField()
     entered_by_name = serializers.SerializerMethodField()
     purchased_by_name = serializers.SerializerMethodField()
     task_name = serializers.SerializerMethodField()
     job_id = serializers.SerializerMethodField()
     job_number = serializers.SerializerMethodField()
     job_name = serializers.SerializerMethodField()
-    invoice = serializers.SerializerMethodField()
     accounting_category_name = serializers.CharField(
         source='accounting_category.name', read_only=True, default=None,
     )
@@ -69,15 +71,6 @@ class ExpenseSerializer(serializers.ModelSerializer):
             'description': {'required': False, 'allow_blank': True},
             'material': {'required': False, 'allow_null': True},
         }
-
-    def get_invoice(self, obj):
-        claims = self.context.get('invoice_claims')
-        if not claims:
-            return None
-        ref = claims.get(('expense', obj.pk))
-        if not ref:
-            return None
-        return {'id': ref['invoice_id'], 'number': ref['invoice_number']}
 
     def _name(self, user):
         if not user:

--- a/apps/api/expenses/serializers.py
+++ b/apps/api/expenses/serializers.py
@@ -27,6 +27,7 @@ class ExpenseSerializer(serializers.ModelSerializer):
     job_id = serializers.SerializerMethodField()
     job_number = serializers.SerializerMethodField()
     job_name = serializers.SerializerMethodField()
+    invoice = serializers.SerializerMethodField()
     accounting_category_name = serializers.CharField(
         source='accounting_category.name', read_only=True, default=None,
     )
@@ -51,6 +52,7 @@ class ExpenseSerializer(serializers.ModelSerializer):
             'reimbursement', 'reimbursement_paid_on',
             'created_at', 'updated_at',
             'new_material',
+            'invoice',
         ]
         read_only_fields = [
             'id', 'entered_by', 'entered_by_name', 'purchased_by_name',
@@ -58,6 +60,7 @@ class ExpenseSerializer(serializers.ModelSerializer):
             'accounting_category_name',
             'status', 'qbo_id', 'qbo_sync_error', 'reimbursement',
             'created_at', 'updated_at',
+            'invoice',
         ]
         extra_kwargs = {
             'purchased_by': {'required': False, 'allow_null': True},
@@ -66,6 +69,15 @@ class ExpenseSerializer(serializers.ModelSerializer):
             'description': {'required': False, 'allow_blank': True},
             'material': {'required': False, 'allow_null': True},
         }
+
+    def get_invoice(self, obj):
+        claims = self.context.get('invoice_claims')
+        if not claims:
+            return None
+        ref = claims.get(('expense', obj.pk))
+        if not ref:
+            return None
+        return {'id': ref['invoice_id'], 'number': ref['invoice_number']}
 
     def _name(self, user):
         if not user:

--- a/apps/api/expenses/views.py
+++ b/apps/api/expenses/views.py
@@ -46,6 +46,28 @@ class ExpenseViewSet(viewsets.ModelViewSet):
             qs = qs.filter(purchased_on__lte=params['to'])
         return qs
 
+    def _claims_context_for(self, expenses):
+        from apps.invoicing.claims import InvoiceClaimService
+        pks = [e.pk for e in expenses]
+        return InvoiceClaimService.claims_for_atoms('expense', pks)
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)
+        objs = page if page is not None else list(queryset)
+        ctx = {**self.get_serializer_context(),
+               'invoice_claims': self._claims_context_for(objs)}
+        serializer = self.get_serializer(objs, many=True, context=ctx)
+        if page is not None:
+            return self.get_paginated_response(serializer.data)
+        return Response(serializer.data)
+
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        ctx = {**self.get_serializer_context(),
+               'invoice_claims': self._claims_context_for([instance])}
+        return Response(self.get_serializer(instance, context=ctx).data)
+
     def perform_create(self, serializer):
         data = serializer.validated_data.copy()
         purchased_by = data.pop('purchased_by', None)

--- a/apps/api/inventory/serializers.py
+++ b/apps/api/inventory/serializers.py
@@ -36,6 +36,7 @@ class MaterialSerializer(serializers.ModelSerializer):
     propagate_to_pli = serializers.BooleanField(
         write_only=True, required=False,
     )
+    invoice = serializers.SerializerMethodField()
 
     class Meta:
         model = Material
@@ -48,6 +49,7 @@ class MaterialSerializer(serializers.ModelSerializer):
             'po_line_item_id', 'po_id', 'po_number', 'po_status',
             'units', 'qty_on_order', 'qty_on_hand',
             'propagate_to_pli',
+            'invoice',
         ]
         read_only_fields = [
             'material_id', 'job', 'task',
@@ -115,6 +117,15 @@ class MaterialSerializer(serializers.ModelSerializer):
             # Earmark-aware availability is surfaced separately (qty_available).
             return str(obj.inventory_item.qty_on_hand)
         return '0'
+
+    def get_invoice(self, obj):
+        claims = self.context.get('invoice_claims')
+        if not claims:
+            return None
+        ref = claims.get(('material', obj.pk))
+        if not ref:
+            return None
+        return {'id': ref['invoice_id'], 'number': ref['invoice_number']}
 
     def update(self, instance, validated_data):
         from apps.inventory.serializer_helpers import (

--- a/apps/api/inventory/serializers.py
+++ b/apps/api/inventory/serializers.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 from rest_framework import serializers
 from apps.inventory.models import InventoryItem, Material
 from apps.core.units import UnitsField
+from apps.api.mixins import InvoiceRefMixin
 
 
 class InventoryItemSerializer(serializers.ModelSerializer):
@@ -23,7 +24,8 @@ class InventoryItemSerializer(serializers.ModelSerializer):
         ]
 
 
-class MaterialSerializer(serializers.ModelSerializer):
+class MaterialSerializer(InvoiceRefMixin, serializers.ModelSerializer):
+    invoice_source_type = 'material'
     is_expense_bound = serializers.BooleanField(read_only=True)
     inventory_item_is_catalog = serializers.SerializerMethodField()
     po_line_item_id = serializers.SerializerMethodField()
@@ -117,15 +119,6 @@ class MaterialSerializer(serializers.ModelSerializer):
             # Earmark-aware availability is surfaced separately (qty_available).
             return str(obj.inventory_item.qty_on_hand)
         return '0'
-
-    def get_invoice(self, obj):
-        claims = self.context.get('invoice_claims')
-        if not claims:
-            return None
-        ref = claims.get(('material', obj.pk))
-        if not ref:
-            return None
-        return {'id': ref['invoice_id'], 'number': ref['invoice_number']}
 
     def update(self, instance, validated_data):
         from apps.inventory.serializer_helpers import (

--- a/apps/api/inventory/views.py
+++ b/apps/api/inventory/views.py
@@ -151,6 +151,11 @@ class MaterialViewSet(viewsets.ModelViewSet):
         from apps.jobs.services import _assert_job_not_on_hold
         try:
             _assert_job_not_on_hold(instance.job, 'edit this material')
+            if 'sell_price' in serializer.validated_data and (
+                serializer.validated_data['sell_price'] != instance.sell_price
+            ):
+                from apps.inventory.services import MaterialService
+                MaterialService._assert_not_invoiced(instance)
         except DjangoValidationError as e:
             detail = e.message_dict if hasattr(e, 'message_dict') else (
                 e.message if hasattr(e, 'message') else str(e)

--- a/apps/api/inventory/views.py
+++ b/apps/api/inventory/views.py
@@ -154,7 +154,6 @@ class MaterialViewSet(viewsets.ModelViewSet):
             if 'sell_price' in serializer.validated_data and (
                 serializer.validated_data['sell_price'] != instance.sell_price
             ):
-                from apps.inventory.services import MaterialService
                 MaterialService._assert_not_invoiced(instance)
         except DjangoValidationError as e:
             detail = e.message_dict if hasattr(e, 'message_dict') else (

--- a/apps/api/jobs/serializers.py
+++ b/apps/api/jobs/serializers.py
@@ -110,6 +110,24 @@ class JobSerializer(JobScopedCanManageMixin, serializers.ModelSerializer):
             return None
         return {'text': entry.text, 'timestamp': entry.timestamp.isoformat()}
 
+    def _invoice_claims(self, obj):
+        """Build the per-job claim map once, memoized. Skipped in list context.
+
+        Returns {} in list context (mirrors the _financials/latest_change_request
+        list-skip pattern) so atom serializers safely receive an empty map.
+        """
+        view = self.context.get('view')
+        if view is not None and getattr(view, 'action', None) == 'list':
+            return {}
+        cache = getattr(self, '_claims_cache', None)
+        if cache is None:
+            cache = {}
+            self._claims_cache = cache
+        if obj.pk not in cache:
+            from apps.invoicing.claims import InvoiceClaimService
+            cache[obj.pk] = InvoiceClaimService.claims_for_job(obj)
+        return cache[obj.pk]
+
     def get_tasks(self, obj):
         from apps.api.tasks.serializers import TaskSerializer
         # Use .all() so prefetch_related cache is hit when configured.
@@ -117,11 +135,17 @@ class JobSerializer(JobScopedCanManageMixin, serializers.ModelSerializer):
         tasks = obj.tasks.all()
         if not hasattr(obj, '_prefetched_objects_cache') or 'tasks' not in obj._prefetched_objects_cache:
             tasks = tasks.order_by('sort_order')
-        return TaskSerializer(tasks, many=True).data
+        return TaskSerializer(
+            tasks, many=True,
+            context={**self.context, 'invoice_claims': self._invoice_claims(obj)},
+        ).data
 
     def get_materials(self, obj):
         from apps.api.inventory.serializers import MaterialSerializer
         materials = obj.materials.all()
         if not hasattr(obj, '_prefetched_objects_cache') or 'materials' not in obj._prefetched_objects_cache:
             materials = materials.order_by('pk')
-        return MaterialSerializer(materials, many=True).data
+        return MaterialSerializer(
+            materials, many=True,
+            context={**self.context, 'invoice_claims': self._invoice_claims(obj)},
+        ).data

--- a/apps/api/mixins.py
+++ b/apps/api/mixins.py
@@ -6,6 +6,28 @@ from rest_framework.response import Response
 from apps.core.services import ServiceError, NotFoundError
 
 
+class InvoiceRefMixin:
+    """Adds a read-only ``invoice`` field — ``{'id', 'number'}`` or ``None`` — to
+    an atom serializer (Task / Material / Expense).
+
+    The single definition of "which invoice is this atom on" for the API layer.
+    The claim map is supplied via serializer context under ``invoice_claims``,
+    keyed by ``(source_type, pk)`` and built once per job/page upstream so there
+    is no N+1. Subclasses set ``invoice_source_type``, declare
+    ``invoice = serializers.SerializerMethodField()`` (DRF's metaclass only
+    collects field declarations from the concrete serializer class, not a plain
+    mixin), and include ``'invoice'`` in ``Meta.fields``.
+    """
+    invoice_source_type = None
+
+    def get_invoice(self, obj):
+        claims = self.context.get('invoice_claims') or {}
+        ref = claims.get((self.invoice_source_type, obj.pk))
+        if ref is None:
+            return None
+        return {'id': ref['invoice_id'], 'number': ref['invoice_number']}
+
+
 class JSONDestroyMixin:
     """
     Override DRF's default destroy() to return 200 with a JSON body instead of

--- a/apps/api/tasks/serializers.py
+++ b/apps/api/tasks/serializers.py
@@ -77,6 +77,7 @@ class TaskSerializer(JobScopedCanManageMixin, serializers.ModelSerializer):
     has_active_blep = serializers.SerializerMethodField()
     active_worker_count = serializers.SerializerMethodField()
     has_bleps = serializers.SerializerMethodField()
+    invoice = serializers.SerializerMethodField()
 
     class Meta:
         model = Task
@@ -91,6 +92,7 @@ class TaskSerializer(JobScopedCanManageMixin, serializers.ModelSerializer):
             'actual_hours',
             'has_active_blep', 'active_worker_count', 'has_bleps',
             'can_manage',
+            'invoice',
         ]
         read_only_fields = ['task_id', 'sort_order', 'status']
 
@@ -127,6 +129,15 @@ class TaskSerializer(JobScopedCanManageMixin, serializers.ModelSerializer):
 
     def get_has_bleps(self, obj):
         return len(obj.blep_set.all()) > 0
+
+    def get_invoice(self, obj):
+        claims = self.context.get('invoice_claims')
+        if not claims:
+            return None
+        ref = claims.get(('task', obj.pk))
+        if not ref:
+            return None
+        return {'id': ref['invoice_id'], 'number': ref['invoice_number']}
 
 
 class TaskDetailSerializer(TaskSerializer):

--- a/apps/api/tasks/serializers.py
+++ b/apps/api/tasks/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from apps.api.mixins import JobScopedCanManageMixin
+from apps.api.mixins import JobScopedCanManageMixin, InvoiceRefMixin
 from apps.jobs.models import Task
 from apps.inventory.models import Material
 from apps.core.models import AccountingCategory
@@ -64,9 +64,10 @@ class MaterialWriteSerializer(serializers.ModelSerializer):
         return super().update(instance, validated_data)
 
 
-class TaskSerializer(JobScopedCanManageMixin, serializers.ModelSerializer):
+class TaskSerializer(JobScopedCanManageMixin, InvoiceRefMixin, serializers.ModelSerializer):
     """Serializer for tasks nested under /api/jobs/{id}/tasks/."""
     can_manage_job_path = 'job'
+    invoice_source_type = 'task'
     assignee_name = serializers.SerializerMethodField()
     actual_hours = serializers.SerializerMethodField()
     scheme_name = serializers.CharField(source='rate_scheme.name', read_only=True, default=None)
@@ -129,15 +130,6 @@ class TaskSerializer(JobScopedCanManageMixin, serializers.ModelSerializer):
 
     def get_has_bleps(self, obj):
         return len(obj.blep_set.all()) > 0
-
-    def get_invoice(self, obj):
-        claims = self.context.get('invoice_claims')
-        if not claims:
-            return None
-        ref = claims.get(('task', obj.pk))
-        if not ref:
-            return None
-        return {'id': ref['invoice_id'], 'number': ref['invoice_number']}
 
 
 class TaskDetailSerializer(TaskSerializer):

--- a/apps/api/tasks/serializers.py
+++ b/apps/api/tasks/serializers.py
@@ -7,9 +7,11 @@ from apps.core.models import AccountingCategory
 from apps.core.units import UnitsField
 
 
-class MaterialSerializer(serializers.ModelSerializer):
+class MaterialSerializer(InvoiceRefMixin, serializers.ModelSerializer):
+    invoice_source_type = 'material'
     is_expense_bound = serializers.BooleanField(read_only=True)
     inventory_item_is_catalog = serializers.SerializerMethodField()
+    invoice = serializers.SerializerMethodField()
 
     class Meta:
         model = Material
@@ -19,6 +21,7 @@ class MaterialSerializer(serializers.ModelSerializer):
             'accounting_category',
             'consumption_state', 'restocked_qty',
             'is_expense_bound', 'inventory_item_is_catalog',
+            'invoice',
         ]
         read_only_fields = fields
 

--- a/apps/api/tasks/views.py
+++ b/apps/api/tasks/views.py
@@ -64,8 +64,12 @@ class TaskViewSet(JobScopedPermissionMixin, RetrieveModelMixin, viewsets.Generic
         from apps.api.tasks.serializers import MaterialSerializer, MaterialWriteSerializer
         task = self.get_object()
         if request.method == 'GET':
+            from apps.invoicing.claims import InvoiceClaimService
             materials = Material.objects.filter(task=task).select_related('inventory_item')
-            serializer = MaterialSerializer(materials, many=True)
+            serializer = MaterialSerializer(
+                materials, many=True,
+                context={'invoice_claims': InvoiceClaimService.claims_for_job(task.job)},
+            )
             return Response(serializer.data)
 
         err = self._check_task_mutable(task)
@@ -169,8 +173,12 @@ class TaskViewSet(JobScopedPermissionMixin, RetrieveModelMixin, viewsets.Generic
         from apps.api.tasks.serializers import TaskSerializer
         task = self.get_object()
         if request.method == 'GET':
+            from apps.invoicing.claims import InvoiceClaimService
             children = Task.objects.filter(parent_task=task).order_by('sort_order')
-            serializer = TaskSerializer(children, many=True)
+            serializer = TaskSerializer(
+                children, many=True,
+                context={'invoice_claims': InvoiceClaimService.claims_for_job(task.job)},
+            )
             return Response(serializer.data)
 
         err = self._check_task_mutable(task)

--- a/apps/api/tasks/views.py
+++ b/apps/api/tasks/views.py
@@ -40,6 +40,18 @@ class TaskViewSet(JobScopedPermissionMixin, RetrieveModelMixin, viewsets.Generic
         from apps.api.tasks.serializers import TaskDetailSerializer
         return TaskDetailSerializer
 
+    def retrieve(self, request, *args, **kwargs):
+        # Pass the job's invoice-claim map so the task's `invoice` field
+        # populates (the task view page shows an INVOICED indicator).
+        from apps.invoicing.claims import InvoiceClaimService
+        task = self.get_object()
+        serializer = self.get_serializer(
+            task,
+            context={**self.get_serializer_context(),
+                     'invoice_claims': InvoiceClaimService.claims_for_job(task.job)},
+        )
+        return Response(serializer.data)
+
     TERMINAL_STATUSES = (Task.STATUS_COMPLETE, Task.STATUS_CANCELLED)
 
     def _get_task_or_404(self, pk):

--- a/apps/core/wizard.py
+++ b/apps/core/wizard.py
@@ -72,6 +72,11 @@ class BaseWizardService:
         """Raise ValidationError unless the container is editable (draft)."""
         raise NotImplementedError
 
+    @classmethod
+    def _assert_atom_billable(cls, instance):
+        """Override to reject atoms that aren't in a billable lifecycle state."""
+        return None
+
     # ── shared atom helpers ────────────────────────────────────────────
     @classmethod
     def _atom_computed_amount(cls, atom_instance):
@@ -213,6 +218,8 @@ class BaseWizardService:
         cls._validate_draft(container)
 
         instances = [cls._resolve_atom(a) for a in atoms]
+        for inst in instances:
+            cls._assert_atom_billable(inst)
         total_price = sum(
             (cls._atom_computed_amount(i) for i in instances),
             Decimal('0.00'),
@@ -263,6 +270,8 @@ class BaseWizardService:
         old_sum = cls._sum_sources(line_item)
         was_in_sync = cls._is_in_sync(line_item, old_sum)
         instances = [cls._resolve_atom(a) for a in atoms]
+        for inst in instances:
+            cls._assert_atom_billable(inst)
 
         try:
             with transaction.atomic():

--- a/apps/expenses/services.py
+++ b/apps/expenses/services.py
@@ -139,20 +139,15 @@ class ExpenseService:
         """Raise if the expense — or its linked material — is on a non-cancelled
         invoice. An expense is immutable while billed (remove it from the invoice
         first)."""
-        from django.db.models import Q
-        from apps.invoicing.models import InvoiceLineItemSource, Invoice
-        live = InvoiceLineItemSource.objects.exclude(
-            invoice_line_item__invoice__status=Invoice.STATUS_CANCELLED
-        )
-        cond = Q(
-            source_type=InvoiceLineItemSource.SOURCE_EXPENSE, source_pk=expense.pk,
-        )
-        if expense.material_id:
-            cond |= Q(
-                source_type=InvoiceLineItemSource.SOURCE_MATERIAL,
-                source_pk=expense.material_id,
+        from apps.invoicing.claims import InvoiceClaimService
+        from apps.invoicing.models import InvoiceLineItemSource
+        if InvoiceClaimService.is_invoiced(
+            InvoiceLineItemSource.SOURCE_EXPENSE, expense.pk,
+        ) or (
+            expense.material_id and InvoiceClaimService.is_invoiced(
+                InvoiceLineItemSource.SOURCE_MATERIAL, expense.material_id,
             )
-        if live.filter(cond).exists():
+        ):
             raise ValidationError(
                 'Cannot edit an expense that is on an invoice; '
                 'remove it from the invoice first.'

--- a/apps/inventory/services.py
+++ b/apps/inventory/services.py
@@ -561,6 +561,19 @@ class MaterialService:
     All earmark mutations go through InventoryService._mutate_earmark."""
 
     @staticmethod
+    def _assert_not_invoiced(material):
+        from django.core.exceptions import ValidationError
+        from apps.invoicing.claims import InvoiceClaimService
+        from apps.invoicing.models import InvoiceLineItemSource
+        if InvoiceClaimService.is_invoiced(
+            InvoiceLineItemSource.SOURCE_MATERIAL, material.pk,
+        ):
+            raise ValidationError(
+                'Cannot change a material that is on an invoice; '
+                'remove it from the invoice first.'
+            )
+
+    @staticmethod
     def update_pricing(material, *, unit_cost=None, sell_price=None, propagate_to_pli=False,
                        cost_source='manual'):
         """Update unit_cost and/or sell_price on a Material. If propagate_to_pli is
@@ -576,6 +589,8 @@ class MaterialService:
         """
         from apps.jobs.services import _assert_job_not_on_hold
         _assert_job_not_on_hold(material.job, 'edit this material')
+        if sell_price is not None and sell_price != material.sell_price:
+            MaterialService._assert_not_invoiced(material)
         from django.db import transaction
         with transaction.atomic():
             update_fields = []
@@ -678,6 +693,7 @@ class MaterialService:
             raise ValidationError(
                 f'unconsume requires consumed state; got {material.consumption_state}'
             )
+        MaterialService._assert_not_invoiced(material)
         qty = material.quantity
         with transaction.atomic():
             pli = material.inventory_item

--- a/apps/invoicing/claims.py
+++ b/apps/invoicing/claims.py
@@ -1,0 +1,43 @@
+from apps.invoicing.models import Invoice, InvoiceLineItemSource
+
+
+class InvoiceClaimService:
+    """Single source of truth for 'is this atom on a live (non-cancelled) invoice'."""
+
+    @staticmethod
+    def _live_sources():
+        return (
+            InvoiceLineItemSource.objects
+            .exclude(invoice_line_item__invoice__status=Invoice.STATUS_CANCELLED)
+        )
+
+    @classmethod
+    def is_invoiced(cls, source_type, source_pk):
+        return cls._live_sources().filter(
+            source_type=source_type, source_pk=source_pk,
+        ).exists()
+
+    @classmethod
+    def _map(cls, queryset):
+        result = {}
+        for src in queryset.select_related('invoice_line_item__invoice'):
+            inv = src.invoice_line_item.invoice
+            result[(src.source_type, src.source_pk)] = {
+                'invoice_id': inv.pk,
+                'invoice_number': inv.invoice_number,
+            }
+        return result
+
+    @classmethod
+    def claims_for_job(cls, job):
+        return cls._map(
+            cls._live_sources().filter(invoice_line_item__invoice__job=job)
+        )
+
+    @classmethod
+    def claims_for_atoms(cls, source_type, pks):
+        if not pks:
+            return {}
+        return cls._map(
+            cls._live_sources().filter(source_type=source_type, source_pk__in=list(pks))
+        )

--- a/apps/invoicing/services.py
+++ b/apps/invoicing/services.py
@@ -416,6 +416,7 @@ class InvoiceWizardService(BaseWizardService):
                     'claiming_line_number': li.line_number,
                     'claiming_invoice_id': None,
                     'claiming_invoice_number': None,
+                    'not_billable_reason': None,
                 }
             else:
                 claims[key] = {
@@ -424,6 +425,7 @@ class InvoiceWizardService(BaseWizardService):
                     'claiming_line_number': None,
                     'claiming_invoice_id': inv.pk,
                     'claiming_invoice_number': inv.invoice_number,
+                    'not_billable_reason': None,
                 }
 
         default_state = {
@@ -432,7 +434,21 @@ class InvoiceWizardService(BaseWizardService):
             'claiming_line_number': None,
             'claiming_invoice_id': None,
             'claiming_invoice_number': None,
+            'not_billable_reason': None,
         }
+
+        def billability(atom_type, instance):
+            if atom_type == 'task' and instance.status != Task.STATUS_COMPLETE:
+                return {'state': 'not_billable', 'not_billable_reason': 'task_incomplete',
+                        'claiming_line_item_id': None, 'claiming_line_number': None,
+                        'claiming_invoice_id': None, 'claiming_invoice_number': None}
+            if atom_type == 'material' and (
+                instance.consumption_state != Material.CONSUMPTION_STATE_CONSUMED
+            ):
+                return {'state': 'not_billable', 'not_billable_reason': 'material_unconsumed',
+                        'claiming_line_item_id': None, 'claiming_line_number': None,
+                        'claiming_invoice_id': None, 'claiming_invoice_number': None}
+            return None
 
         tasks = (
             Task.objects.filter(job=job)
@@ -446,7 +462,7 @@ class InvoiceWizardService(BaseWizardService):
 
             detail = InvoiceWizardService._atom_detail(task)
             key = (InvoiceLineItemSource.SOURCE_TASK, task.pk)
-            state_info = claims.get(key, default_state)
+            state_info = claims.get(key) or billability('task', task) or default_state
             atoms.append({
                 'type': 'task',
                 'id': task.pk,
@@ -467,7 +483,7 @@ class InvoiceWizardService(BaseWizardService):
             for mat in materials:
                 detail = InvoiceWizardService._atom_detail(mat)
                 key = (InvoiceLineItemSource.SOURCE_MATERIAL, mat.pk)
-                state_info = claims.get(key, default_state)
+                state_info = claims.get(key) or billability('material', mat) or default_state
                 atoms.append({
                     'type': 'material',
                     'id': mat.pk,
@@ -496,7 +512,7 @@ class InvoiceWizardService(BaseWizardService):
         for mat in loose:
             detail = InvoiceWizardService._atom_detail(mat)
             key = (InvoiceLineItemSource.SOURCE_MATERIAL, mat.pk)
-            state_info = claims.get(key, default_state)
+            state_info = claims.get(key) or billability('material', mat) or default_state
             loose_atoms.append({
                 'type': 'material',
                 'id': mat.pk,
@@ -574,6 +590,17 @@ class InvoiceWizardService(BaseWizardService):
     def _validate_draft(cls, container):
         if container.status != Invoice.STATUS_DRAFT:
             raise ValidationError('Wizard can only modify draft invoices.')
+
+    @classmethod
+    def _assert_atom_billable(cls, instance):
+        from apps.jobs.models import Task
+        from apps.inventory.models import Material
+        if isinstance(instance, Task) and instance.status != Task.STATUS_COMPLETE:
+            raise ValidationError('Cannot bill a task that is not complete.')
+        if isinstance(instance, Material) and (
+            instance.consumption_state != Material.CONSUMPTION_STATE_CONSUMED
+        ):
+            raise ValidationError('Cannot bill a material that is not consumed.')
 
     @classmethod
     def _expense_model(cls):

--- a/apps/jobs/services.py
+++ b/apps/jobs/services.py
@@ -887,6 +887,14 @@ class TaskService:
         except Task.DoesNotExist:
             raise NotFoundError(f'Task {pk} not found')
         _assert_job_not_on_hold(task.job, 'edit this task')
+        # A complete task is terminal and frozen: its work and billing inputs are
+        # settled. sort_order is cosmetic (list position) and stays editable so a
+        # list containing a complete task can still be reordered.
+        if task.status == Task.STATUS_COMPLETE and set(kwargs) - {'sort_order'}:
+            raise ValidationError(
+                'Cannot edit a complete task. Its work and billing are settled; '
+                'corrections belong on the invoice.'
+            )
         for field, value in kwargs.items():
             setattr(task, field, value)
         task.full_clean()

--- a/apps/jobs/services.py
+++ b/apps/jobs/services.py
@@ -269,6 +269,11 @@ class BlepService:
              Job.STATUS_WORK_COMPLETE, Job.STATUS_CANCELLED),
             'log time',
         )
+        if task.status == Task.STATUS_COMPLETE:
+            raise ValidationError(
+                "Cannot log time on a complete task. Create a new task for "
+                "additional work."
+            )
         if end_time < start_time:
             raise ValidationError("end_time must be >= start_time.")
         if end_time > timezone.now() + BlepService._CLOCK_SKEW_BUFFER:

--- a/docs/designs/LATER.md
+++ b/docs/designs/LATER.md
@@ -350,6 +350,20 @@ page stays whole.
   confusing. Converge on one. _Done when:_ adding a manual line item uses the same component
   whether on the detail page or in the wizard.
 
+- **Material added to an already-started Task is never consumed.** — _added 2026-06-17_
+  Adding a Material to a Task *after* the Task has started is allowed (correct), but the
+  newly-added material stays `pending` forever — continued work on the task doesn't consume
+  it. Consumption of a task's materials is a one-shot side effect triggered when the task is
+  *promoted* from `pending → in_progress` (the first blep: `start_work` /
+  `_promote_pending_task` → `MaterialService.consume` over `task.materials.all()`,
+  `apps/jobs/services.py`). A material attached later misses that already-fired trigger, so it
+  never consumes (no QOH/earmark decrement, never billable since billable ⟺ consumed). Decide
+  the intended behavior: e.g. consume a material on add when its task is already `in_progress`
+  (and only then), or re-run the consume sweep on subsequent bleps for not-yet-consumed
+  materials. Watch the `unconsume`/blep-cancel-undo interaction either way.
+  _Done when:_ a material added to an in-progress task gets consumed by continued work (with a
+  test), or a recorded decision says it must be added before start.
+
 - **Should a superseded estimate's tab navigate to the current estimate?** — _added 2026-06-03_
   In job view, clicking a superseded estimate's tab shows that (old) estimate in the pillar, and
   its "View Full Estimate" link correctly points to the old one. Open question: should clicking

--- a/docs/designs/LATER.md
+++ b/docs/designs/LATER.md
@@ -364,19 +364,35 @@ page stays whole.
   _Done when:_ a material added to an in-progress task gets consumed by continued work (with a
   test), or a recorded decision says it must be added before start.
 
-- **Grouped atoms with matching units don't propagate units to the line item.** — _added 2026-06-17_
-  In the invoice/estimate wizard, grouping several atoms into one line item only carries the
-  shared **units** onto the line when the bundle is a *uniform same-scheme task* bundle
-  (`BaseWizardService._uniform_scheme_bundle` in `apps/core/wizard.py`: all atoms are Tasks with
-  one RateScheme + identical `active_modifiers`, units taken from the scheme). Every other group
-  that *does* share a unit — e.g. several materials with the same units, or tasks with the same
-  units but different schemes — falls through to `units='none'` even though a common unit exists.
-  Price still comes out right (the fallback sums to the correct total), so the symptom is
-  "pricing copied but units blank." Fix direction: in the multi-atom fallback (and the parallel
-  `_resync_in_sync_line_item`), if `_atom_units(...)` is identical across all grouped atoms, set
-  the line item's units to that shared value instead of `'none'`; keep qty/price behavior as-is.
-  _Done when:_ grouping atoms that all share a unit yields a line item carrying that unit (with a
-  test for the same-units-non-uniform-scheme and same-units-materials cases).
+- **Grouped same-scheme (hourly) tasks: rate copies but units don't.** — _added 2026-06-17_
+  In the invoice wizard, grouping several Tasks that share one (hourly) RateScheme into a line
+  item copies the **rate** correctly but leaves the line item's **units** blank. Because the rate
+  comes through right, `_uniform_scheme_bundle` (`apps/core/wizard.py`) *did* run — and its return
+  `(scheme.unit_label, qty, price)` is also what sets the line item's `units`. So the leading
+  suspect is that the hourly scheme's `RateScheme.unit_label` is empty (elapsed/hourly schemes may
+  never populate it, since qty is time), whereas the user-entered scheme in the sibling report has
+  a unit_label (units copied there). Needs reproduction to confirm data (empty `unit_label` on the
+  scheme) vs. code (a path that drops it), and to check whether the group went through
+  `add_atoms_to_new_line_item` or the add-to-existing `_resync_in_sync_line_item`.
+  **Also reproduces on the estimate wizard** (qty and price copy correctly, units don't) — same
+  shared `BaseWizardService` machinery, with `plan_task`/`plan_material` sources — so this is a
+  shared wizard-path / unit_label issue, not invoice-specific. _Done when:_ grouping same-scheme
+  atoms (invoice and estimate) yields a line item with the scheme's unit (and, if hourly schemes
+  are meant to read "hours", that `unit_label` is populated/derived), with a test.
+
+- **Single task on an entered-qty scheme collapses to qty 1 / price = total.** — _added 2026-06-17_
+  Sending ONE Task atom with a user-entered-quantity scheme to a new line item shows qty 1 and
+  price = the full amount (observed: entered qty 2.2 × rate 22 → line item qty 1, price 48.40),
+  instead of qty 2.2 / price 22 with the total computed from them. Units copy fine here. Root
+  cause: `InvoiceWizardService._task_qty_and_price` (`apps/invoicing/services.py`) returns
+  `(Decimal('1'), total_price)` for *every* single task ("no single qty/price is meaningful across
+  all algorithms"). But for entered-qty (and flat) schemes a real qty×rate *does* exist —
+  `_atom_detail` already computes `qty = _task_actual_qty(task)` and `rate = effective_rate()` for
+  the source-pool display. Fix direction: for single-task lines, use the scheme's actual qty and
+  effective rate when the algorithm has a meaningful per-unit qty (entered/flat), falling back to
+  qty 1 / total only where it genuinely doesn't (e.g. elapsed bleps, if that's still desired).
+  _Done when:_ a single entered-qty task lands on the line item as qty=actual / price=rate with
+  the total derived, with a test; revisit the elapsed-scheme case deliberately.
 
 - **Should a superseded estimate's tab navigate to the current estimate?** — _added 2026-06-03_
   In job view, clicking a superseded estimate's tab shows that (old) estimate in the pillar, and

--- a/docs/designs/LATER.md
+++ b/docs/designs/LATER.md
@@ -364,6 +364,20 @@ page stays whole.
   _Done when:_ a material added to an in-progress task gets consumed by continued work (with a
   test), or a recorded decision says it must be added before start.
 
+- **Grouped atoms with matching units don't propagate units to the line item.** — _added 2026-06-17_
+  In the invoice/estimate wizard, grouping several atoms into one line item only carries the
+  shared **units** onto the line when the bundle is a *uniform same-scheme task* bundle
+  (`BaseWizardService._uniform_scheme_bundle` in `apps/core/wizard.py`: all atoms are Tasks with
+  one RateScheme + identical `active_modifiers`, units taken from the scheme). Every other group
+  that *does* share a unit — e.g. several materials with the same units, or tasks with the same
+  units but different schemes — falls through to `units='none'` even though a common unit exists.
+  Price still comes out right (the fallback sums to the correct total), so the symptom is
+  "pricing copied but units blank." Fix direction: in the multi-atom fallback (and the parallel
+  `_resync_in_sync_line_item`), if `_atom_units(...)` is identical across all grouped atoms, set
+  the line item's units to that shared value instead of `'none'`; keep qty/price behavior as-is.
+  _Done when:_ grouping atoms that all share a unit yields a line item carrying that unit (with a
+  test for the same-units-non-uniform-scheme and same-units-materials cases).
+
 - **Should a superseded estimate's tab navigate to the current estimate?** — _added 2026-06-03_
   In job view, clicking a superseded estimate's tab shows that (old) estimate in the pillar, and
   its "View Full Estimate" link correctly points to the old one. Open question: should clicking

--- a/docs/designs/LATER.md
+++ b/docs/designs/LATER.md
@@ -604,3 +604,11 @@ IMAP-SMTP machinery and tend to be worked together.
   property) + the column in `InventoryListPage`. Helps decide whether to hit the
   new per-row "order" button or wait on stock already coming.
   _Done when:_ the inventory list shows an accurate on-order quantity per item.
+
+- **Expense invoice-freeze has no billability-readiness gate, by design.** — _added 2026-06-17_
+  Expense atoms have an invoice-freeze (`ExpenseService._assert_not_invoiced`)
+  but no separate billability-readiness gate — they appear as selectable in the
+  wizard pool from the moment they are submitted (unlike Tasks, which require
+  `complete`, and Materials, which require `consumed`). This is deliberate: an
+  expense is ready to bill as soon as it exists. Revisit only if a
+  "not ready to bill" expense state is ever needed.

--- a/docs/designs/LATER.md
+++ b/docs/designs/LATER.md
@@ -364,22 +364,6 @@ page stays whole.
   _Done when:_ a material added to an in-progress task gets consumed by continued work (with a
   test), or a recorded decision says it must be added before start.
 
-- **Grouped same-scheme (hourly) tasks: rate copies but units don't.** — _added 2026-06-17_
-  In the invoice wizard, grouping several Tasks that share one (hourly) RateScheme into a line
-  item copies the **rate** correctly but leaves the line item's **units** blank. Because the rate
-  comes through right, `_uniform_scheme_bundle` (`apps/core/wizard.py`) *did* run — and its return
-  `(scheme.unit_label, qty, price)` is also what sets the line item's `units`. So the leading
-  suspect is that the hourly scheme's `RateScheme.unit_label` is empty (elapsed/hourly schemes may
-  never populate it, since qty is time), whereas the user-entered scheme in the sibling report has
-  a unit_label (units copied there). Needs reproduction to confirm data (empty `unit_label` on the
-  scheme) vs. code (a path that drops it), and to check whether the group went through
-  `add_atoms_to_new_line_item` or the add-to-existing `_resync_in_sync_line_item`.
-  **Also reproduces on the estimate wizard** (qty and price copy correctly, units don't) — same
-  shared `BaseWizardService` machinery, with `plan_task`/`plan_material` sources — so this is a
-  shared wizard-path / unit_label issue, not invoice-specific. _Done when:_ grouping same-scheme
-  atoms (invoice and estimate) yields a line item with the scheme's unit (and, if hourly schemes
-  are meant to read "hours", that `unit_label` is populated/derived), with a test.
-
 - **Single task on an entered-qty scheme collapses to qty 1 / price = total.** — _added 2026-06-17_
   Sending ONE Task atom with a user-entered-quantity scheme to a new line item shows qty 1 and
   price = the full amount (observed: entered qty 2.2 × rate 22 → line item qty 1, price 48.40),

--- a/docs/designs/LATER.md
+++ b/docs/designs/LATER.md
@@ -378,6 +378,21 @@ page stays whole.
   _Done when:_ a single entered-qty task lands on the line item as qty=actual / price=rate with
   the total derived, with a test; revisit the elapsed-scheme case deliberately.
 
+- **Adding a Task to a `work_complete` job doesn't reopen the job.** — _added 2026-06-17_
+  A new Task can be added to a Job that's already at `work_complete`, and the job stays
+  `work_complete` — even though it now has unfinished work, which contradicts what that status
+  means (all tasks done). Task creation (`TaskCreationService.create_direct` /
+  `create_from_template`, `apps/jobs/services.py`) only gates on `_assert_job_not_on_hold`, and
+  the only auto-advance is `JobService.mark_work_started`, which fires `approved → in_progress`
+  on a blep/complete — never on task creation, and a no-op for `work_complete`. The transition
+  map *does* allow `work_complete → in_progress`, so the fix is to pull the job back to
+  `in_progress` when an incomplete task is added (or its work begins) on a `work_complete` job.
+  Related, decide the harder case: task creation is also allowed on a **terminal `completed`**
+  job (only `on_hold` is blocked), which has no outgoing transition to reopen — so either block
+  adding tasks there or define a reopen path. _Done when:_ adding an incomplete task to a
+  `work_complete` job returns it to `in_progress` (with a test), and the `completed`-job case is
+  decided (blocked or reopenable).
+
 - **Should a superseded estimate's tab navigate to the current estimate?** — _added 2026-06-03_
   In job view, clicking a superseded estimate's tab shows that (old) estimate in the pillar, and
   its "View Full Estimate" link correctly points to the old one. Open question: should clicking

--- a/docs/designs/estimates-and-prices.md
+++ b/docs/designs/estimates-and-prices.md
@@ -585,6 +585,7 @@ Atom families:
 |---|---|---|
 | `PlanTask` | `Task` | this doc / jobs-tasks |
 | `PlanMaterial` | `Material` | materials doc |
+| _(no plan-side)_ | `Expense` (material-less) | invoicing-and-expenses doc |
 
 Bleps are read-only detail under their task's atom; they are never
 claimed as atoms themselves. **Whole-task billing**: there is no
@@ -597,6 +598,28 @@ Atom claim semantics:
 - An atom is **claimed** if a source row exists pointing at it.
 - The DB-level unique on `(source_type, source_pk)` makes
   double-claim impossible.
+
+### Wizard-pool billability gates (invoice side)
+
+The invoice wizard's source pool (`InvoiceWizardService.get_source_pool`)
+distinguishes between atoms that are available to bill and those that are not
+yet ready:
+
+| Atom type | Billable when |
+|---|---|
+| `Task` | `status == complete` |
+| `Material` | `consumption_state == consumed` |
+| `Expense` (material-less) | always (submitted is sufficient; no readiness gate) |
+
+Non-billable atoms appear in the pool with `state='not_billable'` and a
+`not_billable_reason` (`'task_incomplete'` or `'material_unconsumed'`). They
+are rendered greyed-out and non-selectable in `WizardSourcePool.svelte` so
+the invoicer can see what is pending without being able to add it yet.
+
+`InvoiceWizardService._assert_atom_billable` is the service-side enforcement
+point: it re-checks readiness when atoms are actually submitted to the wizard
+(i.e. when `add_atoms_to_new_line_item` / `add_atoms_to_line_item` resolve
+each atom), raising `ValidationError` if the readiness condition is not met.
 
 A worksheet exposes two top-level operations on its atoms:
 

--- a/docs/designs/invoicing-and-expenses.md
+++ b/docs/designs/invoicing-and-expenses.md
@@ -193,6 +193,12 @@ The field is populated without N+1:
   they inherit the indicator. The task's own `invoice` field is populated by a
   `retrieve` override on `TaskViewSet` that passes the `claims_for_job` map as
   context.
+- `ExpenseListPage.svelte` shows an **"INVOICED · INV-xxxx"** badge in the Status
+  cell of any billed (loose) expense, and **hides the mutating actions** (edit /
+  reject / delete) for it — replacing them with a "billed — locked" note — since
+  `ExpenseService.update` and `delete` both reject an invoiced expense
+  server-side (`_assert_not_invoiced`). Material-bound expenses bill via their
+  material, so only loose expenses ever show the badge.
 
 ### Per-source stacked list on line items
 

--- a/docs/designs/invoicing-and-expenses.md
+++ b/docs/designs/invoicing-and-expenses.md
@@ -187,6 +187,12 @@ The field is populated without N+1:
   status column: for an invoiced task/subtask it **replaces** the activity/status
   indicator (an invoiced task is necessarily `complete`), and for an invoiced
   material it fills the otherwise-empty status cell. Both link to the invoice.
+- `TaskDetailPage.svelte` (the single-task view) shows the **"INVOICED"** link on
+  the Status row (replacing the activity indicator) and beside each invoiced
+  material in its inline materials table; its subtasks render via `TaskTree`, so
+  they inherit the indicator. The task's own `invoice` field is populated by a
+  `retrieve` override on `TaskViewSet` that passes the `claims_for_job` map as
+  context.
 
 ### Per-source stacked list on line items
 

--- a/docs/designs/invoicing-and-expenses.md
+++ b/docs/designs/invoicing-and-expenses.md
@@ -72,6 +72,31 @@ Guaranteed by the application-level get-or-create in `InvoiceWizardService.open_
 
 ---
 
+## InvoiceClaimService — centralized invoiced-atom predicate
+
+`InvoiceClaimService` (`apps/invoicing/claims.py`) is the **single source of
+truth** for "is this atom on a live (non-cancelled) invoice." All service-layer
+code that needs to answer that question uses this class — no inline filter
+duplication.
+
+```python
+InvoiceClaimService.is_invoiced(source_type, source_pk) → bool
+    # True if the atom is referenced by any non-cancelled InvoiceLineItemSource.
+
+InvoiceClaimService.claims_for_job(job) → dict
+    # {(source_type, source_pk): {'invoice_id': N, 'invoice_number': '…'}, …}
+    # Used by JobSerializer to populate the per-atom `invoice` field
+    # in one query per job (no N+1).
+
+InvoiceClaimService.claims_for_atoms(source_type, pks) → dict
+    # Same shape, scoped to a specific list of PKs of one type.
+```
+
+`_live_sources()` excludes sources whose invoice is `cancelled` — a
+cancelled invoice frees its claimed atoms back to the pool.
+
+---
+
 ## InvoiceLineItem and InvoiceLineItemSource
 
 `apps/invoicing/models.py`.
@@ -124,6 +149,61 @@ When the wizard hits a race, `InvoiceWizardService` catches `IntegrityError` and
 - Deleting an `InvoiceLineItem` deletes its `InvoiceLineItemSource` rows (CASCADE).
 - Deleting an `Invoice` cascades to its line items, then to their sources. All claimed atoms become available again.
 - Deleting a `Task` or `Material` does not affect `InvoiceLineItemSource` rows directly (no FK; the join uses `source_type`+`source_pk`). A claimed atom that gets deleted leaves a dangling source whose `resolve()` raises `DoesNotExist`. Atom deletion is gated upstream — Tasks with bleps don't get hard-deleted in normal flows.
+
+### Per-atom `invoice` field (API) and "Invoiced" indicator (UI)
+
+**API:** `TaskSerializer`, `MaterialSerializer`, and `ExpenseSerializer` all
+expose a top-level `invoice` field:
+
+```json
+"invoice": {"id": 42, "number": "INV-2026-0003"}
+// or null when the atom is unclaimed / claimed only by a cancelled invoice
+```
+
+The field is populated without N+1:
+
+- **Tasks and Materials** (nested under the job): `JobSerializer._invoice_claims(job)`
+  calls `InvoiceClaimService.claims_for_job(job)` once and passes the resulting
+  dict as `invoice_claims` context to `TaskSerializer` and `MaterialSerializer`.
+  In list contexts (where `view.action == 'list'`), the claims map is skipped
+  and `invoice` returns `null` to avoid the per-job overhead.
+- **Expenses** (via `ExpenseViewSet`): `ExpenseViewSet._claims_context_for`
+  calls `InvoiceClaimService.claims_for_atoms('expense', pks)` once per list/
+  retrieve response and passes the dict as `invoice_claims` context.
+
+**UI:** `JobDetail.svelte` renders an `invoicedLink` snippet next to each task
+row, material row, and loose-expense row in the job overview. When a task's,
+material's, or expense's `invoice` field is non-null, a small **"Invoiced ·
+INV-xxxx"** badge appears, linking to that invoice's detail page. The badge is
+absent when the atom is unclaimed.
+
+### Per-source stacked list on line items
+
+`InvoiceLineItemSerializer` includes a nested `sources` array
+(via `InvoiceLineItemSourceSerializer`):
+
+```json
+"sources": [
+    {"source_id": 11, "source_type": "task", "source_pk": 5,
+     "description": "CNC Router (setup)", "computed_amount": "120.00"},
+    {"source_id": 12, "source_type": "material", "source_pk": 3,
+     "description": "Plywood — 4×8 (2 sheets)", "computed_amount": "48.00"}
+]
+```
+
+`InvoiceLineItemSourceSerializer.get_description` resolves the atom via
+`obj.resolve()` and delegates to `InvoiceWizardService._atom_description`.
+`get_computed_amount` calls `InvoiceWizardService._atom_computed_amount`.
+
+`WizardLineItemCard.svelte` renders these as a stacked `↳ description ✕` list
+below the line item's price row, with per-source remove buttons. This replaces
+the old "N atoms" count.
+
+The **estimate** side has a parallel implementation: `EstimateLineItemSerializer`
+includes `EstimateLineItemSourceSerializer` with the same `description` +
+`computed_amount` fields (resolved via `EstimateWizardService._atom_description`
+/ `_atom_computed_amount`), shown in the same stacked layout on
+`WizardLineItemCard` for estimate line items.
 
 ---
 
@@ -396,8 +476,10 @@ wrong job is the same as any other edit. Moving a material-linked expense to
 another job moves its material too (composing `InventoryService.unconsume` →
 move earmark → re-consume for a consumed inventoried material). The one hard
 lock: an expense is **immutable while it — or its material — is on a
-non-cancelled invoice** (`ExpenseService._assert_not_invoiced`, checked in
-`update`/`delete`). To edit a billed expense, remove it from the invoice first.
+non-cancelled invoice** (`ExpenseService._assert_not_invoiced`, which delegates
+to `InvoiceClaimService.is_invoiced` — the same centralized predicate used by
+`MaterialService._assert_not_invoiced`; checked in `update`/`delete`). To edit
+a billed expense, remove it from the invoice first.
 `reject()`'s consumed-material wall still applies to *rejection* (not to editing).
 
 A second money lock covers reimbursement: once an expense is **reimbursed** (in a
@@ -425,6 +507,11 @@ type, and `InvoiceLineItemSource` gained `SOURCE_EXPENSE`.
 - **Already-invoiced:** once on a non-cancelled invoice, the expense shows
   `claimed_by_*` in the pool (not removed) — same as Materials/Tasks. This is
   also exactly what freezes the expense (see above).
+- **Billability gate:** expenses have **no readiness gate** in the wizard pool —
+  they are always selectable as long as they are not already claimed. (Tasks
+  require `complete`; Materials require `consumed`; Expenses are billable from
+  the moment they are submitted.) See `docs/designs/estimates-and-prices.md` §7
+  for the wizard-pool billability rules.
 
 ### Status machine
 

--- a/docs/designs/invoicing-and-expenses.md
+++ b/docs/designs/invoicing-and-expenses.md
@@ -167,15 +167,26 @@ The field is populated without N+1:
   dict as `invoice_claims` context to `TaskSerializer` and `MaterialSerializer`.
   In list contexts (where `view.action == 'list'`), the claims map is skipped
   and `invoice` returns `null` to avoid the per-job overhead.
+- **Task-list page atoms** (the `tasklist` view re-fetches per-task children):
+  the flat `TaskViewSet.materials` and `subtasks` GET actions each build
+  `InvoiceClaimService.claims_for_job(task.job)` and pass it as `invoice_claims`
+  context to the tasks-app `MaterialSerializer` / `TaskSerializer`, so materials
+  and subtasks fetched there also carry `invoice`. (The tasks-app
+  `MaterialSerializer` gained the `invoice` field via `InvoiceRefMixin` too.)
 - **Expenses** (via `ExpenseViewSet`): `ExpenseViewSet._claims_context_for`
   calls `InvoiceClaimService.claims_for_atoms('expense', pks)` once per list/
   retrieve response and passes the dict as `invoice_claims` context.
 
-**UI:** `JobDetail.svelte` renders an `invoicedLink` snippet next to each task
-row, material row, and loose-expense row in the job overview. When a task's,
-material's, or expense's `invoice` field is non-null, a small **"Invoiced ·
-INV-xxxx"** badge appears, linking to that invoice's detail page. The badge is
-absent when the atom is unclaimed.
+**UI:**
+- `JobDetail.svelte` renders an `invoicedLink` snippet next to each task row,
+  material row, and loose-expense row in the job overview. When a task's,
+  material's, or expense's `invoice` field is non-null, a small **"Invoiced ·
+  INV-xxxx"** badge appears, linking to that invoice's detail page. The badge is
+  absent when the atom is unclaimed.
+- `TaskTree.svelte` (the task-list page) shows an **"INVOICED"** link in the
+  status column: for an invoiced task/subtask it **replaces** the activity/status
+  indicator (an invoiced task is necessarily `complete`), and for an invoiced
+  material it fills the otherwise-empty status cell. Both link to the invoice.
 
 ### Per-source stacked list on line items
 

--- a/docs/designs/jobs-tasks-and-worksheets.md
+++ b/docs/designs/jobs-tasks-and-worksheets.md
@@ -497,6 +497,35 @@ pending→in_progress promotion, not of every clock-in.
 `reorder_tasks`. Deletion is rejected for `in_progress` / `complete`
 tasks and for any task with at least one Blep — cancel instead.
 
+#### Task freeze on `complete`
+
+`complete` is a **terminal** state: once a task is complete, its work and
+billing inputs are settled.
+
+- **All fields are frozen** except `sort_order`. `TaskService.update_task`
+  raises `ValidationError` if any field other than `sort_order` is included
+  in an update for a complete task:
+
+  ```
+  "Cannot edit a complete task. Its work and billing are settled;
+  corrections belong on the invoice."
+  ```
+
+- **No new Bleps**: `BlepService.create_historical` (and `start_work`)
+  reject new time entries against a complete task:
+
+  ```
+  "Cannot log time on a complete task. Create a new task for additional work."
+  ```
+
+- **`sort_order` exemption**: list position is cosmetic. A complete task
+  embedded in a mixed list can still be reordered without touching any
+  billing data.
+
+- **No reopen**: there is no `complete → pending/in_progress` transition.
+  A task that needs more work after being marked complete gets a new
+  sibling task.
+
 ### 4.6 Conflict resolution: join vs takeover
 
 When `start_work` is called on a Task that's already `in_progress` and

--- a/docs/designs/materials-inventory-and-purchasing.md
+++ b/docs/designs/materials-inventory-and-purchasing.md
@@ -279,6 +279,26 @@ transaction. The propagate action is open to any authenticated user
 (deliberate carve-out from `can_manage_financials`). See
 `MaterialService.update_pricing` and `InventoryService.update_plan_material_pricing`.
 
+**Invoice freeze on `sell_price` and `unconsume`.** Once a Material is on a
+non-cancelled invoice (i.e. `InvoiceClaimService.is_invoiced('material', pk)`
+returns True), two operations are hard-blocked by
+`MaterialService._assert_not_invoiced`:
+
+- **`sell_price` edits** — `MaterialService.update_pricing` raises
+  `ValidationError` if `sell_price` is being changed while the material is
+  claimed. (`unit_cost` edits are still allowed — cost is internal data,
+  not the invoiced price.)
+- **`unconsume`** — `MaterialService.unconsume` raises `ValidationError`
+  before reversing consumption. Moving a material back to `pending` while it
+  is on an invoice would change the invoiced amount and remove it from the
+  wizard pool incorrectly.
+
+`quantity` is already locked by the consumed state (all user ops require
+`pending`), so no additional invoice-freeze is needed for quantity.
+
+To edit a billed material's sell price or unconsume it, remove it from the
+invoice first.
+
 Enforcement lives in `apps/inventory/serializer_helpers.py`
 (`enforce_pli_linked_allowlist`, `PLI_LINKED_PRICING_ALLOWED`,
 `FREEFORM_ALLOWED`) and is invoked from `MaterialSerializer.update`.

--- a/docs/plans/2026-06-17-invoiced-atom-visibility-and-freeze-design.md
+++ b/docs/plans/2026-06-17-invoiced-atom-visibility-and-freeze-design.md
@@ -1,0 +1,241 @@
+# Invoiced-atom visibility + freeze — design
+
+**Date:** 2026-06-17
+**Branch:** feature/invoiced-atoms
+**Status:** design, pending implementation plan
+
+## Problem
+
+The system already knows which billable atoms (Task work, Materials, Expenses)
+have been attached to an invoice — but that knowledge is buried inside the
+invoice wizard. On the job views (starting with the overview) there is no way to
+see that a Task or Material has already been billed.
+
+Worse, the underlying data lets an atom's billed amount **drift after it's been
+invoiced**: a Task's billing inputs and a Material's `sell_price` are editable
+even once the atom is on an invoice. The invoice line item itself is a snapshot
+and does not change, but the atom's "I've been invoiced" mark becomes a lie when
+its current computed amount no longer matches what was billed.
+
+This feature does two things:
+
+1. **Visibility** — surface a per-atom "Invoiced" indicator (a link to the
+   invoice) on the job overview's Tasks and Materials & Expenses pillars.
+2. **Integrity** — guarantee that an invoiced atom can never change its billed
+   amount, by combining lifecycle gates (when an atom *becomes* billable) with
+   freezes (what locks once it's billed).
+
+## How "invoiced" is recorded today (background)
+
+There is **no flag on the atom and no FK** from Task/Material/Expense to an
+invoice line. The single source of truth is the join table
+**`InvoiceLineItemSource`** (`apps/invoicing/models.py:160`), keyed on
+`(source_type, source_pk)` with a DB-level `unique_together` on that pair. An
+atom is "invoiced" iff a row exists in that table pointing at it via a
+**non-cancelled** invoice. The `unique_together` makes splitting an atom across
+invoices physically impossible: one atom → at most one line item → one invoice,
+so the "link to the invoice" is always unambiguous.
+
+Invoice line items are `BaseLineItem`s that store their own `qty`/`units`/`price`
+written once at creation (`apps/core/wizard.py:242`); the invoice total
+aggregates those stored values (`apps/jobs/financials.py:135`). The only
+re-derivation from atoms (`_resync_in_sync_line_item`) is gated to `DRAFT`
+invoices (`_validate_draft`). So **a sent invoice's amounts never mutate** — the
+drift we care about is the atom's mark becoming inaccurate, not the invoice
+document changing.
+
+## The unified invariant
+
+> Once an atom has a non-cancelled `InvoiceLineItemSource`, it is read-only on
+> every field that feeds its billed amount.
+
+Each atom type reaches that invariant differently, because each becomes billable
+at a different lifecycle point.
+
+| Atom | Billable when | Frozen by |
+|---|---|---|
+| **Task** | `status == complete` | **Completion** freezes the whole task (terminal, no reopen) — bleps and all fields. Invoiced ⟹ complete ⟹ already frozen, so no invoice-specific task freeze is needed. |
+| **Material** | `consumption_state == consumed` | `consumed` already locks quantity (restock/draw_more require `pending`). The invoice freeze adds: block `sell_price` edits and block `unconsume`. |
+| **Expense** | submitted & not rejected (money already spent — billable immediately) | **Already implemented**: `ExpenseService._assert_not_invoiced` blocks all edits while the expense (or its linked material) is on a non-cancelled invoice. No new freeze code. |
+
+### Why these specific gates
+
+- **Task — freeze everything on complete.** `complete` is terminal
+  (`STATUS_COMPLETE: []`, `apps/jobs/models.py:330`); there is no reopen and a
+  complete task cannot be cancelled. We deliberately freeze *all* of the task on
+  completion (not a two-stage complete-then-invoice freeze). Rationale: the rule
+  is trivial to explain ("a complete task is done — done working, done
+  editing"), and error-correction is still fully available because **invoice
+  line items are independently editable** — the atom values are only the
+  *starting defaults* for invoicing. No reopen path is built; if one is ever
+  needed it can be added later.
+- **Material — billable ⟺ consumed.** Task-attached materials auto-consume when
+  their task *starts* (`apps/jobs/services.py:984`, `:1181`); task-less
+  materials are consumed manually. This matches reality: a material is "used up"
+  (and its quantity locked) at task start, well before the labor finishes — so
+  materials legitimately become billable earlier than their parent task's
+  labor. A `pending` (undrawn) material is not billable.
+- **Expense — no readiness gate.** Unlike work-to-be-done (task) or
+  stock-to-be-drawn (material), an expense is a sunk cost that is real the
+  instant it's submitted. Rejected expenses simply never enter the pool. So
+  expenses get **no greyed "not billable yet" state**.
+
+### Deletion integrity (already covered — no work)
+
+An invoiced atom must not be deleted out from under its source row (the source
+is keyed by `source_pk`, not a real FK, so a delete would orphan it). This is
+already prevented by existing state rules:
+
+- Invoiced ⟹ task `complete` ⟹ `delete_task` refuses it (and it can't be
+  cancelled — terminal). Safe.
+- Invoiced ⟹ material `consumed`; `Material.destroy` is disabled (405,
+  `apps/api/inventory/views.py:120`) and every deletion path
+  (`restock`-to-zero, `sever`, expense rejection) requires `pending`. Safe.
+
+## Scope
+
+### Part 1 — Centralize the "is invoiced" predicate
+
+Create one helper in the invoicing layer (e.g. `InvoiceClaimService`):
+
+- `is_invoiced(atom)` → bool — does a non-cancelled `InvoiceLineItemSource`
+  reference this atom? (mirrors the existing
+  `ExpenseService._assert_not_invoiced` filter)
+- `claims_for_job(job)` → `{(source_type, source_pk): {invoice_id, invoice_number}}`
+  in **one query**, for the no-N+1 indicator.
+
+Refactor `ExpenseService._assert_not_invoiced` to use the shared predicate
+(preserving its expense-or-linked-material behavior). This is the single source
+of truth used by the freeze guards, the wizard billability gate, `get_source_pool`,
+and the indicator.
+
+### Part 2 — Freeze enforcement
+
+- **Task:** `TaskService.update_task` (`apps/jobs/services.py:883`) rejects edits
+  to a `complete` task — **except `sort_order`** (list position is cosmetic and
+  unrelated to work/billing; freezing it would block reordering any list
+  containing a complete task). Both blep-creation paths (`create_historical` and
+  the live-start path) reject a `complete` task.
+- **Material:** once a material has a non-cancelled invoice source:
+  - `MaterialService.update_pricing` (`apps/inventory/services.py:564`) rejects
+    `sell_price` changes.
+  - The freeform `partial_update` path
+    (`apps/api/inventory/views.py:159`) rejects amount-affecting field changes.
+  - `MaterialService.unconsume` (`apps/inventory/services.py:677`) is blocked,
+    and `TaskLifecycleService.cancel_work` refuses (or is guarded) when any of
+    the task's materials are invoiced.
+- **Expense:** already done (`_assert_not_invoiced`); no change beyond the
+  refactor in Part 1.
+
+### Part 3 — Wizard billability gates
+
+In `InvoiceWizardService.get_source_pool` (`apps/invoicing/services.py:438`) and
+the add-atoms write path (defense in depth — the wizard isn't guaranteed to be
+the only caller):
+
+- **Task atoms:** a new atom state `not_billable` with reason "task not
+  complete" for non-`complete` tasks. Shown **greyed / non-selectable** in the
+  wizard (mirroring the existing `claimed_by_other` shown-but-disabled pattern),
+  **not hidden**. The task's child materials remain listed independently.
+- **Material atoms:** `not_billable` with reason "not consumed" for `pending`
+  materials. Greyed / non-selectable.
+- **Expense atoms:** unchanged (no readiness gate).
+- The add-atoms write path rejects a non-`complete` task or non-`consumed`
+  material.
+
+### Part 4 — Indicator API
+
+Add an `invoice` field (`null`, or `{id, number}`) to:
+
+- `TaskSerializer` (`apps/api/tasks/serializers.py`)
+- `MaterialSerializer` (`apps/api/inventory/serializers.py`)
+- the Expense serializer (loose/material-less expenses)
+
+Fed by `InvoiceClaimService.claims_for_job(job)` built once in `JobSerializer`
+and passed via serializer context. The atom serializers read from context when
+present and emit `null` otherwise — so expanding to the task list / task detail
+later is just "pass the same context." No N+1.
+
+### Part 5 — Overview UI (`frontend/src/components/jobs/JobDetail.svelte`)
+
+- **Tasks pillar:** render an "Invoiced" marker on any task carrying an
+  `invoice`, as a link to `#/invoices/{id}` (links navigate, per UI conventions).
+- **Materials & Expenses pillar:**
+  - Material rows: same "Invoiced" link when the material carries an `invoice`.
+  - Material-linked expenses already annotate their material row; the link lives
+    on the material (the expense isn't separately billable).
+  - Loose (material-less) expense rows: the "Invoiced" link when the expense
+    carries an `invoice`.
+- Atoms without an `invoice` are unmarked.
+
+### Part 6 — Detail the sources on a line item (display only)
+
+Today a line item's Source column shows only a count — `"N atom(s)"` — from
+`sourceLabel` in the shared `frontend/src/components/LineItemTable.svelte:23`.
+The full per-source detail is **already serialized** and sent to the client
+(`InvoiceLineItemSourceSerializer`, `apps/api/invoicing/serializers.py:22`):
+each `li.sources[]` entry carries `source_type`, `source_pk`, `description`, and
+`computed_amount`. The frontend just collapses it to a count.
+
+Change: replace the count with a **stacked list** — one source per row under the
+line, showing the atom's `description` and its `computed_amount`. This is a
+**pure frontend change**; no backend, no new query, no serializer work.
+
+Notes:
+
+- `LineItemTable.svelte` is **shared**: both the invoice detail page and the
+  estimate detail page render it with `showSource={true}`. The estimate source
+  serializer (`apps/api/estimates/serializers.py:7`) exposes the identical
+  `source_type` / `description` / `computed_amount` shape, so this improves both
+  detail views at once with no extra work.
+- Fallback: if the stacked list reads as too heavy in practice, fall back to a
+  compact comma-joined list of descriptions. (Decision: ship the stacked list
+  first; the comma-join is the cheap retreat.)
+- `"No source"` (manually-authored line items with no atoms) is unchanged.
+
+## Out of scope
+
+- Expanding the indicator to the task list / task detail pages. The serializer
+  context approach is built to make this a trivial follow-up, but it is not in
+  this pass (overview first; expand after confirming the read).
+- A reopen-from-complete transition for tasks (not built; revisit only if the
+  no-correction-window assumption proves wrong).
+- Distinguishing draft vs. finalized/sent invoices in the indicator — the mark
+  is binary ("on a non-cancelled invoice").
+
+## Testing (TDD)
+
+Backend (`tests/`, run singly — never parallel):
+
+- `InvoiceClaimService.is_invoiced` / `claims_for_job` correctness, including
+  cancelled-invoice exclusion and the expense-or-linked-material case.
+- Task freeze: `update_task` rejects field edits on a complete task; `sort_order`
+  still allowed; both blep paths reject a complete task.
+- Material freeze: `update_pricing` and freeform `partial_update` reject
+  `sell_price` on an invoiced material; `unconsume`/`cancel_work` blocked when
+  invoiced.
+- Wizard: `get_source_pool` marks non-complete tasks and pending materials
+  `not_billable`; child materials of a non-complete task still appear; add-atoms
+  rejects non-complete task / non-consumed material.
+- Serializers: `invoice` field is `null` vs `{id, number}` correctly; no N+1
+  (assert query count).
+- Expense freeze refactor preserves existing behavior.
+
+Frontend (`frontend/tests/`, Vitest):
+
+- `JobDetail.svelte` renders the "Invoiced" link on invoiced tasks, materials,
+  and loose expenses, and omits it otherwise; link targets `#/invoices/{id}`.
+- `LineItemTable.svelte` renders the stacked per-source list (description +
+  amount) when `showSource` and `li.sources` is non-empty; `"No source"` when
+  empty. Covers both invoice and estimate line items.
+
+## Docs to update on completion
+
+- `docs/designs/invoicing-and-expenses.md` — the freeze invariant, billability
+  gates, and the centralized claim predicate.
+- `docs/designs/estimates-and-prices.md` — billable-atom billability gates
+  (complete / consumed / submitted).
+- `docs/designs/jobs-tasks-and-worksheets.md` — task freeze-on-complete; no
+  bleps on complete tasks.
+- `docs/designs/materials-inventory-and-purchasing.md` — material invoice freeze
+  (sell_price, unconsume).

--- a/docs/plans/2026-06-17-invoiced-atom-visibility-and-freeze-plan.md
+++ b/docs/plans/2026-06-17-invoiced-atom-visibility-and-freeze-plan.md
@@ -1,0 +1,1238 @@
+# Invoiced-atom Visibility + Freeze Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a per-atom "Invoiced" link on the job overview and detail the sources on each line item, and guarantee an invoiced atom can never change its billed amount.
+
+**Architecture:** One centralized predicate (`InvoiceClaimService`) answers "is this atom invoiced, and on which invoice." Freeze guards on the task/material write paths enforce immutability of amount-feeding fields once an atom is billable (task `complete`) or billed (material). The wizard gates billability by lifecycle (task `complete`, material `consumed`). Serializers expose an `invoice` field fed by a per-job claim map (no N+1). The frontend renders the indicator and a stacked per-source list.
+
+**Tech Stack:** Django 5.2 + DRF (MySQL), Svelte 5 SPA (Vite), Django TestCase (`tests/`), Vitest (`frontend/tests/`).
+
+## Global Constraints
+
+- **Never write to the dev DB.** Tests use their own DB; never run `migrate`, `shell`, `loaddata`, or ORM writes against dev. Read-only SQL SELECT is OK for diagnostics.
+- **TDD always:** failing test → verify it fails → minimal code → verify pass → commit.
+- **Run tests singly, never in parallel** (`python manage.py test tests.test_x`); shared MySQL test DB deadlocks otherwise.
+- Use model status constants, never string literals (`Task.STATUS_COMPLETE`, `Invoice.STATUS_CANCELLED`, `Material.CONSUMPTION_STATE_CONSUMED`).
+- **Line item deletes** go through `LineItemService.delete_line_item_with_renumber` (not relevant here, but do not introduce direct line-item `.delete()`).
+- All DELETE responses return 200 with JSON (not relevant here; no new DELETEs).
+- Frontend: no CSS frameworks; links navigate (`<a use:link>` / `href="#/..."`), buttons act; semantic HTML.
+- On completion, update `docs/designs/` docs listed at the end. `docs/plans/` is the disposable working dir.
+
+**Source spec:** `docs/plans/2026-06-17-invoiced-atom-visibility-and-freeze-design.md`
+
+---
+
+## File Structure
+
+**Backend — create:**
+- `apps/invoicing/claims.py` — `InvoiceClaimService` (the centralized predicate + batch maps).
+
+**Backend — modify:**
+- `apps/expenses/services.py` — refactor `_assert_not_invoiced` onto `InvoiceClaimService`.
+- `apps/jobs/services.py` — task freeze in `TaskService.update_task`; blep freeze in `BlepService.create_historical`.
+- `apps/inventory/services.py` — material freeze in `update_pricing` and `unconsume`.
+- `apps/api/inventory/views.py` — material freeze in `MaterialViewSet.partial_update` (freeform sell_price path).
+- `apps/invoicing/services.py` — `get_source_pool` billability gates; add-atoms write-path guard (in `apps/core/wizard.py` via a hook).
+- `apps/api/jobs/serializers.py` — build `claims_for_job` and pass via context to task/material serializers.
+- `apps/api/tasks/serializers.py` — `invoice` field on `TaskSerializer`.
+- `apps/api/inventory/serializers.py` — `invoice` field on `MaterialSerializer`.
+- `apps/api/expenses/serializers.py` + `apps/api/expenses/views.py` — `invoice` field on `ExpenseSerializer` + context map.
+
+**Frontend — modify:**
+- `frontend/src/components/jobs/JobDetail.svelte` — "Invoiced" link on tasks, materials, loose expenses.
+- `frontend/src/components/invoices/WizardSourcePool.svelte` + `WizardAtom` — greyed `not_billable` state.
+- `frontend/src/components/LineItemTable.svelte` — stacked per-source list.
+
+**Tests:**
+- `tests/test_invoice_claims.py` (new), and additions to `tests/test_api_materials.py`, `tests/test_api_bleps.py`, `tests/test_api_jobs.py`, `tests/test_api_invoicing.py`, `tests/test_api_expenses.py`.
+- `frontend/tests/JobDetail.invoiced.test.js`, `frontend/tests/LineItemTable.test.js`, `frontend/tests/WizardSourcePool.test.js` (new or extended).
+
+---
+
+## Task 1: `InvoiceClaimService` — centralized predicate + batch maps
+
+**Files:**
+- Create: `apps/invoicing/claims.py`
+- Test: `tests/test_invoice_claims.py`
+
+**Interfaces:**
+- Produces:
+  - `InvoiceClaimService.is_invoiced(source_type: str, source_pk: int) -> bool`
+  - `InvoiceClaimService.claims_for_job(job) -> dict[tuple[str,int], dict]` where each value is `{'invoice_id': int, 'invoice_number': str}`
+  - `InvoiceClaimService.claims_for_atoms(source_type: str, pks: list[int]) -> dict[tuple[str,int], dict]`
+  - Constants reused: `InvoiceLineItemSource.SOURCE_TASK`, `SOURCE_MATERIAL`, `SOURCE_EXPENSE`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_invoice_claims.py
+from decimal import Decimal
+from tests.base import BaseTestCase
+from apps.invoicing.claims import InvoiceClaimService
+from apps.invoicing.models import Invoice, InvoiceLineItem, InvoiceLineItemSource
+
+
+class InvoiceClaimServiceTest(BaseTestCase):
+    def _make_invoice_line_with_source(self, job, source_type, source_pk, status):
+        inv = Invoice.objects.create(job=job, status=status)
+        li = InvoiceLineItem.objects.create(
+            invoice=inv, description='x', qty=Decimal('1'),
+            units='none', price=Decimal('5.00'),
+        )
+        InvoiceLineItemSource.objects.create(
+            invoice_line_item=li, source_type=source_type, source_pk=source_pk,
+        )
+        return inv
+
+    def test_is_invoiced_true_for_live_source(self):
+        job = self.make_job()  # see note below
+        self._make_invoice_line_with_source(
+            job, InvoiceLineItemSource.SOURCE_TASK, 4242, Invoice.STATUS_DRAFT,
+        )
+        self.assertTrue(
+            InvoiceClaimService.is_invoiced(InvoiceLineItemSource.SOURCE_TASK, 4242)
+        )
+
+    def test_is_invoiced_false_when_only_cancelled(self):
+        job = self.make_job()
+        self._make_invoice_line_with_source(
+            job, InvoiceLineItemSource.SOURCE_TASK, 4243, Invoice.STATUS_CANCELLED,
+        )
+        self.assertFalse(
+            InvoiceClaimService.is_invoiced(InvoiceLineItemSource.SOURCE_TASK, 4243)
+        )
+
+    def test_claims_for_job_keys_and_excludes_cancelled(self):
+        job = self.make_job()
+        self._make_invoice_line_with_source(
+            job, InvoiceLineItemSource.SOURCE_MATERIAL, 11, Invoice.STATUS_DRAFT,
+        )
+        self._make_invoice_line_with_source(
+            job, InvoiceLineItemSource.SOURCE_TASK, 22, Invoice.STATUS_CANCELLED,
+        )
+        claims = InvoiceClaimService.claims_for_job(job)
+        self.assertIn((InvoiceLineItemSource.SOURCE_MATERIAL, 11), claims)
+        self.assertNotIn((InvoiceLineItemSource.SOURCE_TASK, 22), claims)
+        ref = claims[(InvoiceLineItemSource.SOURCE_MATERIAL, 11)]
+        self.assertEqual(set(ref.keys()), {'invoice_id', 'invoice_number'})
+```
+
+> **Note on `self.make_job()`:** if `BaseTestCase` has no such helper, create a minimal Job inline using the project's existing job-creation test pattern (grep `tests/test_api_invoicing.py` for how invoices+jobs are built in setUp) and reuse that exact pattern. Do **not** invent fields.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python manage.py test tests.test_invoice_claims -v 2`
+Expected: FAIL with `ModuleNotFoundError: apps.invoicing.claims`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# apps/invoicing/claims.py
+from apps.invoicing.models import Invoice, InvoiceLineItemSource
+
+
+class InvoiceClaimService:
+    """Single source of truth for 'is this atom on a live (non-cancelled) invoice'."""
+
+    @staticmethod
+    def _live_sources():
+        return (
+            InvoiceLineItemSource.objects
+            .exclude(invoice_line_item__invoice__status=Invoice.STATUS_CANCELLED)
+        )
+
+    @classmethod
+    def is_invoiced(cls, source_type, source_pk):
+        return cls._live_sources().filter(
+            source_type=source_type, source_pk=source_pk,
+        ).exists()
+
+    @classmethod
+    def _map(cls, queryset):
+        result = {}
+        for src in queryset.select_related('invoice_line_item__invoice'):
+            inv = src.invoice_line_item.invoice
+            result[(src.source_type, src.source_pk)] = {
+                'invoice_id': inv.pk,
+                'invoice_number': inv.invoice_number,
+            }
+        return result
+
+    @classmethod
+    def claims_for_job(cls, job):
+        return cls._map(
+            cls._live_sources().filter(invoice_line_item__invoice__job=job)
+        )
+
+    @classmethod
+    def claims_for_atoms(cls, source_type, pks):
+        if not pks:
+            return {}
+        return cls._map(
+            cls._live_sources().filter(source_type=source_type, source_pk__in=list(pks))
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python manage.py test tests.test_invoice_claims -v 2`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Refactor `ExpenseService._assert_not_invoiced` onto the predicate**
+
+In `apps/expenses/services.py`, replace the body of `_assert_not_invoiced` (currently `apps/expenses/services.py:137-159`) so the live-source query is delegated, preserving the expense-or-linked-material behavior:
+
+```python
+    @staticmethod
+    def _assert_not_invoiced(expense):
+        """Raise if the expense — or its linked material — is on a non-cancelled
+        invoice. An expense is immutable while billed (remove it from the invoice
+        first)."""
+        from apps.invoicing.claims import InvoiceClaimService
+        from apps.invoicing.models import InvoiceLineItemSource
+        if InvoiceClaimService.is_invoiced(
+            InvoiceLineItemSource.SOURCE_EXPENSE, expense.pk,
+        ) or (
+            expense.material_id and InvoiceClaimService.is_invoiced(
+                InvoiceLineItemSource.SOURCE_MATERIAL, expense.material_id,
+            )
+        ):
+            raise ValidationError(
+                'Cannot edit an expense that is on an invoice; '
+                'remove it from the invoice first.'
+            )
+```
+
+- [ ] **Step 6: Run the expense suite to verify the refactor is behavior-preserving**
+
+Run: `python manage.py test tests.test_api_expenses -v 2`
+Expected: PASS (no regressions).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/invoicing/claims.py tests/test_invoice_claims.py apps/expenses/services.py
+git commit -m "feat(invoicing): centralize is-invoiced predicate in InvoiceClaimService
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Task freeze on `complete` (field edits)
+
+**Files:**
+- Modify: `apps/jobs/services.py` (`TaskService.update_task`, currently `apps/jobs/services.py:883-894`)
+- Test: `tests/test_api_jobs.py` (or `tests/test_api_job_tasklist.py` — use whichever already builds tasks; check both, pick the one with task-edit coverage)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `update_task` raises `django.core.exceptions.ValidationError` when editing any field of a `complete` task except `sort_order`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# in the task-editing test module (mirror its existing setUp for building a task)
+from django.core.exceptions import ValidationError
+from apps.jobs.models import Task
+from apps.jobs.services import TaskService
+
+def test_update_task_rejects_edit_on_complete_task(self):
+    task = self._make_task()                 # reuse the module's existing helper
+    task.status = Task.STATUS_COMPLETE
+    task.save(update_fields=['status'])
+    with self.assertRaises(ValidationError):
+        TaskService.update_task(task.pk, name='renamed')
+
+def test_update_task_allows_sort_order_on_complete_task(self):
+    task = self._make_task()
+    task.status = Task.STATUS_COMPLETE
+    task.save(update_fields=['status'])
+    # sort_order is cosmetic; must remain editable
+    TaskService.update_task(task.pk, sort_order=5)
+    task.refresh_from_db()
+    self.assertEqual(task.sort_order, 5)
+```
+
+> Reuse the existing task-builder in that test module (grep for `Task.objects.create(` or `create_direct` in the file). Do not invent task fields.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python manage.py test tests.test_api_jobs -v 2` (adjust module)
+Expected: FAIL — first test does not raise; edit succeeds.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Modify `TaskService.update_task` (`apps/jobs/services.py:883`):
+
+```python
+    @staticmethod
+    def update_task(pk, **kwargs):
+        """Update an existing Task by PK."""
+        try:
+            task = Task.objects.get(pk=pk)
+        except Task.DoesNotExist:
+            raise NotFoundError(f'Task {pk} not found')
+        _assert_job_not_on_hold(task.job, 'edit this task')
+        # A complete task is terminal and frozen: its work and billing inputs are
+        # settled. sort_order is cosmetic (list position) and stays editable so a
+        # list containing a complete task can still be reordered.
+        if task.status == Task.STATUS_COMPLETE and set(kwargs) - {'sort_order'}:
+            raise ValidationError(
+                'Cannot edit a complete task. Its work and billing are settled; '
+                'corrections belong on the invoice.'
+            )
+        for field, value in kwargs.items():
+            setattr(task, field, value)
+        task.full_clean()
+        task.save()
+        return task
+```
+
+> Confirm `ValidationError` is imported in this module (it is used elsewhere, e.g. `apps/jobs/services.py:42`). If not, add `from django.core.exceptions import ValidationError`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python manage.py test tests.test_api_jobs -v 2`
+Expected: PASS. Then run the broader task suite to catch fixtures that edit completed tasks:
+Run: `python manage.py test tests.test_api_job_tasklist tests.test_api_jobs -v 2`
+Expected: PASS (fix any test that legitimately edited a complete task by adjusting that test's setup, not by weakening the guard).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/jobs/services.py tests/test_api_jobs.py
+git commit -m "feat(jobs): freeze a complete task's fields (except sort_order)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Blep freeze — no historical bleps on a `complete` task
+
+**Files:**
+- Modify: `apps/jobs/services.py` (`BlepService.create_historical`, `apps/jobs/services.py:246`)
+- Test: `tests/test_api_bleps.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `BlepService.create_historical(...)` raises `ValidationError` when `task.status == Task.STATUS_COMPLETE`. (The live `start_work` path already rejects non-pending/in-progress tasks at `apps/jobs/services.py:1168` — no change there.)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_api_bleps.py — reuse the module's user/task/shift setup
+from django.core.exceptions import ValidationError
+from apps.jobs.models import Task
+from apps.jobs.services import BlepService
+
+def test_create_historical_rejects_complete_task(self):
+    task = self._make_task_with_open_window()   # reuse existing helper/setup
+    task.status = Task.STATUS_COMPLETE
+    task.save(update_fields=['status'])
+    start, end = self._recent_interval()        # reuse existing time helpers
+    with self.assertRaises(ValidationError):
+        BlepService.create_historical(
+            actor=self.user, task=task, start_time=start, end_time=end,
+        )
+```
+
+> Grep `tests/test_api_bleps.py` for how it currently builds a task + a covering shift and reuse those helpers verbatim; a blep requires an enclosing shift (`apps/jobs/services.py:286`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python manage.py test tests.test_api_bleps -v 2`
+Expected: FAIL — blep is created on the complete task.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `BlepService.create_historical`, add the guard immediately after the existing job-status assertion (`apps/jobs/services.py:266-271`):
+
+```python
+        if task.status == Task.STATUS_COMPLETE:
+            raise ValidationError(
+                "Cannot log time on a complete task. Create a new task for "
+                "additional work."
+            )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python manage.py test tests.test_api_bleps -v 2`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/jobs/services.py tests/test_api_bleps.py
+git commit -m "feat(jobs): reject historical bleps on a complete task
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Material freeze — sell_price + unconsume on an invoiced material
+
+**Files:**
+- Modify: `apps/inventory/services.py` (`update_pricing` `:564`, `unconsume` `:677`)
+- Modify: `apps/api/inventory/views.py` (`MaterialViewSet.partial_update` `:123`, freeform branch)
+- Test: `tests/test_api_materials.py`
+
+**Interfaces:**
+- Consumes: `InvoiceClaimService.is_invoiced` (Task 1).
+- Produces:
+  - `MaterialService.update_pricing(...)` raises `ValidationError` if the material is invoiced and `sell_price` would change.
+  - `MaterialService.unconsume(material)` raises `ValidationError` if the material is invoiced.
+  - `PATCH /api/materials/{id}/` with `sell_price` on an invoiced freeform material returns 400.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_api_materials.py — reuse the module's material + invoice builders
+from decimal import Decimal
+from django.core.exceptions import ValidationError
+from apps.inventory.services import MaterialService
+from apps.inventory.models import Material
+from apps.invoicing.models import Invoice, InvoiceLineItem, InvoiceLineItemSource
+
+def _invoice_material(self, material):
+    inv = Invoice.objects.create(job=material.job, status=Invoice.STATUS_DRAFT)
+    li = InvoiceLineItem.objects.create(
+        invoice=inv, description='m', qty=material.quantity,
+        units='none', price=material.sell_price,
+    )
+    InvoiceLineItemSource.objects.create(
+        invoice_line_item=li,
+        source_type=InvoiceLineItemSource.SOURCE_MATERIAL,
+        source_pk=material.pk,
+    )
+
+def test_update_pricing_blocks_sell_price_when_invoiced(self):
+    mat = self._make_consumed_material()        # reuse existing helper
+    self._invoice_material(mat)
+    with self.assertRaises(ValidationError):
+        MaterialService.update_pricing(mat, sell_price=Decimal('99.00'))
+
+def test_unconsume_blocked_when_invoiced(self):
+    mat = self._make_consumed_material()
+    self._invoice_material(mat)
+    with self.assertRaises(ValidationError):
+        MaterialService.unconsume(mat)
+```
+
+> Reuse the module's existing helpers for building a consumed material (grep `consume(` / `CONSUMPTION_STATE_CONSUMED` in the file). If none exists, build one with `MaterialService.create_on_job(...)` then `MaterialService.consume(...)` using the same args the module already uses.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python manage.py test tests.test_api_materials -v 2`
+Expected: FAIL — pricing change and unconsume both succeed.
+
+- [ ] **Step 3: Implement the service guards**
+
+In `apps/inventory/services.py`, add a small helper near the top of `MaterialService` and call it:
+
+```python
+    @staticmethod
+    def _assert_not_invoiced(material):
+        from apps.invoicing.claims import InvoiceClaimService
+        from apps.invoicing.models import InvoiceLineItemSource
+        if InvoiceClaimService.is_invoiced(
+            InvoiceLineItemSource.SOURCE_MATERIAL, material.pk,
+        ):
+            raise ValidationError(
+                'Cannot change a material that is on an invoice; '
+                'remove it from the invoice first.'
+            )
+```
+
+In `update_pricing` (`:564`), after the on-hold assertion and before mutating, guard only when `sell_price` actually changes:
+
+```python
+        from apps.jobs.services import _assert_job_not_on_hold
+        _assert_job_not_on_hold(material.job, 'edit this material')
+        if sell_price is not None and sell_price != material.sell_price:
+            MaterialService._assert_not_invoiced(material)
+```
+
+In `unconsume` (`:677`), add the guard at the top (after the existing state check):
+
+```python
+        if material.consumption_state != Material.CONSUMPTION_STATE_CONSUMED:
+            raise ValidationError(
+                f'unconsume requires consumed state; got {material.consumption_state}'
+            )
+        MaterialService._assert_not_invoiced(material)
+```
+
+> Confirm `ValidationError` (`django.core.exceptions`) is imported in `apps/inventory/services.py`; it is used throughout, so it is. Do not add a duplicate import.
+
+- [ ] **Step 4: Add the API-layer test for the freeform path**
+
+```python
+# tests/test_api_materials.py — uses the DRF test client the module already sets up
+def test_patch_sell_price_blocked_on_invoiced_freeform_material(self):
+    mat = self._make_consumed_freeform_material()   # no inventory_item
+    self._invoice_material(mat)
+    self.client.force_login(self.user)              # match module's auth pattern
+    resp = self.client.patch(
+        f'/api/materials/{mat.pk}/', {'sell_price': '77.00'},
+        content_type='application/json',
+    )
+    self.assertEqual(resp.status_code, 400)
+```
+
+- [ ] **Step 5: Implement the view guard (freeform branch)**
+
+In `apps/api/inventory/views.py` `partial_update` (`:123`), the PLI-linked pricing branch already routes through `update_pricing` (now guarded). Add the guard to the freeform/non-pricing branch before `serializer.save()` (`:159`):
+
+```python
+        # Freeform path or non-pricing fields: assert not on_hold before saving,
+        # then fall through to the default serializer save.
+        from apps.jobs.services import _assert_job_not_on_hold
+        try:
+            _assert_job_not_on_hold(instance.job, 'edit this material')
+            if 'sell_price' in serializer.validated_data and (
+                serializer.validated_data['sell_price'] != instance.sell_price
+            ):
+                from apps.inventory.services import MaterialService
+                MaterialService._assert_not_invoiced(instance)
+        except DjangoValidationError as e:
+            detail = e.message_dict if hasattr(e, 'message_dict') else (
+                e.message if hasattr(e, 'message') else str(e)
+            )
+            return Response({'detail': detail}, status=status.HTTP_400_BAD_REQUEST)
+        serializer.save()
+        return Response(MaterialSerializer(instance).data)
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `python manage.py test tests.test_api_materials -v 2`
+Expected: PASS. Then run the inventory + purchasing suites for regressions:
+Run: `python manage.py test tests.test_api_inventory tests.test_api_purchasing -v 2`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/inventory/services.py apps/api/inventory/views.py tests/test_api_materials.py
+git commit -m "feat(inventory): freeze sell_price and unconsume on an invoiced material
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Wizard billability gates (task complete, material consumed)
+
+**Files:**
+- Modify: `apps/invoicing/services.py` (`get_source_pool` `:437-488`; add per-type billability hook for the add-atoms write path)
+- Modify: `apps/core/wizard.py` (`add_atoms_to_new_line_item` `:210`, `add_atoms_to_line_item` `:257` — call a billability hook)
+- Test: `tests/test_api_invoicing.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces:
+  - `get_source_pool` atom dicts may carry `state == 'not_billable'` with `not_billable_reason` (`'task_incomplete'` or `'material_unconsumed'`).
+  - `InvoiceWizardService` rejects adding a non-`complete` task or non-`consumed` material as an atom (raises `ValidationError`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_api_invoicing.py — reuse the module's job/task/material/invoice setup
+from apps.jobs.models import Task
+from apps.inventory.models import Material
+from apps.invoicing.services import InvoiceWizardService
+
+def test_source_pool_marks_incomplete_task_not_billable(self):
+    # task left in a non-complete status
+    pool = InvoiceWizardService.get_source_pool(self.invoice)
+    task_atom = self._find_atom(pool, 'task', self.incomplete_task.pk)
+    self.assertEqual(task_atom['state'], 'not_billable')
+    self.assertEqual(task_atom['not_billable_reason'], 'task_incomplete')
+
+def test_source_pool_marks_pending_material_not_billable(self):
+    pool = InvoiceWizardService.get_source_pool(self.invoice)
+    mat_atom = self._find_atom(pool, 'material', self.pending_material.pk)
+    self.assertEqual(mat_atom['state'], 'not_billable')
+    self.assertEqual(mat_atom['not_billable_reason'], 'material_unconsumed')
+
+def test_add_atoms_rejects_incomplete_task(self):
+    from django.core.exceptions import ValidationError
+    with self.assertRaises(ValidationError):
+        InvoiceWizardService.add_atoms_to_new_line_item(
+            self.invoice, [{'type': 'task', 'id': self.incomplete_task.pk}],
+        )
+```
+
+> `_find_atom(pool, type, id)` is a small test helper: walk `pool['tasks'][*]['atoms']` (and the loose-materials group) for a matching `type`+`id`. Add it to the test module if not present. Reuse the module's existing invoice/task/material builders for `self.incomplete_task` / `self.pending_material`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python manage.py test tests.test_api_invoicing -v 2`
+Expected: FAIL — atoms come back `available`; add succeeds.
+
+- [ ] **Step 3: Implement billability in `get_source_pool`**
+
+In `apps/invoicing/services.py`, define a `default_state` for a non-billable atom and apply it before the claim lookup. Replace the task-atom state assignment (`:448-449`) and the material-atom state assignment (`:469-470`) so a non-billable lifecycle wins over `available` (but a real claim still shows as claimed):
+
+```python
+        def billability(atom_type, instance):
+            if atom_type == 'task' and instance.status != Task.STATUS_COMPLETE:
+                return {'state': 'not_billable', 'not_billable_reason': 'task_incomplete',
+                        'claiming_line_item_id': None, 'claiming_line_number': None,
+                        'claiming_invoice_id': None, 'claiming_invoice_number': None}
+            if atom_type == 'material' and (
+                instance.consumption_state != Material.CONSUMPTION_STATE_CONSUMED
+            ):
+                return {'state': 'not_billable', 'not_billable_reason': 'material_unconsumed',
+                        'claiming_line_item_id': None, 'claiming_line_number': None,
+                        'claiming_invoice_id': None, 'claiming_invoice_number': None}
+            return None
+```
+
+Then for the task atom:
+
+```python
+            key = (InvoiceLineItemSource.SOURCE_TASK, task.pk)
+            state_info = claims.get(key) or billability('task', task) or default_state
+```
+
+and for each material atom (both the task-attached loop `:469` and the loose-materials loop):
+
+```python
+                key = (InvoiceLineItemSource.SOURCE_MATERIAL, mat.pk)
+                state_info = claims.get(key) or billability('material', mat) or default_state
+```
+
+> `Task` and `Material` are already imported at the top of `get_source_pool` (`apps/invoicing/services.py:393-394`). Add `'not_billable_reason': None` to the shared `default_state` dict (`:429-435`) so every atom carries the key uniformly.
+
+- [ ] **Step 4: Implement the add-atoms write guard**
+
+Add a billability hook to the wizard base and override it for invoices. In `apps/core/wizard.py`, in both `add_atoms_to_new_line_item` (after `instances = [...]`, `:215`) and `add_atoms_to_line_item` (after `instances = [...]`, `:265`):
+
+```python
+        for inst in instances:
+            cls._assert_atom_billable(inst)
+```
+
+Add the default no-op hook to the base class:
+
+```python
+    @classmethod
+    def _assert_atom_billable(cls, instance):
+        """Override to reject atoms that aren't in a billable lifecycle state."""
+        return None
+```
+
+Override it in `InvoiceWizardService` (`apps/invoicing/services.py`):
+
+```python
+    @classmethod
+    def _assert_atom_billable(cls, instance):
+        from apps.jobs.models import Task
+        from apps.inventory.models import Material
+        if isinstance(instance, Task) and instance.status != Task.STATUS_COMPLETE:
+            raise ValidationError('Cannot bill a task that is not complete.')
+        if isinstance(instance, Material) and (
+            instance.consumption_state != Material.CONSUMPTION_STATE_CONSUMED
+        ):
+            raise ValidationError('Cannot bill a material that is not consumed.')
+```
+
+> `ValidationError` is already imported in `apps/invoicing/services.py`. Expenses have no billability gate (override does nothing for them).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python manage.py test tests.test_api_invoicing -v 2`
+Expected: PASS. Existing wizard tests may have billed in-progress tasks / pending materials — fix those tests to complete/consume the atom first (the new rule is correct), not by weakening the guard.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/invoicing/services.py apps/core/wizard.py tests/test_api_invoicing.py
+git commit -m "feat(invoicing): gate wizard billability — task complete, material consumed
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: `invoice` field on Task + Material serializers (via job claim map)
+
+**Files:**
+- Modify: `apps/api/jobs/serializers.py` (`get_tasks` `:113-120`, `get_materials` `:122-127`)
+- Modify: `apps/api/tasks/serializers.py` (`TaskSerializer`)
+- Modify: `apps/api/inventory/serializers.py` (`MaterialSerializer`)
+- Test: `tests/test_api_jobs.py`
+
+**Interfaces:**
+- Consumes: `InvoiceClaimService.claims_for_job` (Task 1).
+- Produces: job-detail payload `tasks[*].invoice` and `materials[*].invoice` = `null` or `{id, number}`. Context key: `invoice_claims` = `{(source_type, source_pk): {invoice_id, invoice_number}}`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_api_jobs.py — reuse the module's job-detail GET pattern
+def test_job_detail_marks_invoiced_task(self):
+    # arrange: a complete task on the job, put on a draft invoice line+source
+    self._invoice_task(self.task)               # add helper mirroring Task 4's _invoice_material
+    self.client.force_login(self.user)
+    resp = self.client.get(f'/api/jobs/{self.job.pk}/')
+    self.assertEqual(resp.status_code, 200)
+    task_row = next(t for t in resp.json()['tasks'] if t['task_id'] == self.task.pk)
+    self.assertIsNotNone(task_row['invoice'])
+    self.assertEqual(set(task_row['invoice'].keys()), {'id', 'number'})
+
+def test_job_detail_uninvoiced_task_has_null_invoice(self):
+    self.client.force_login(self.user)
+    resp = self.client.get(f'/api/jobs/{self.job.pk}/')
+    task_row = next(t for t in resp.json()['tasks'] if t['task_id'] == self.task.pk)
+    self.assertIsNone(task_row['invoice'])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python manage.py test tests.test_api_jobs -v 2`
+Expected: FAIL — `KeyError: 'invoice'`.
+
+- [ ] **Step 3: Add the `invoice` field to both atom serializers**
+
+Add a reusable mixin (same shape for both). In `apps/api/tasks/serializers.py`, add to `TaskSerializer`:
+
+```python
+    invoice = serializers.SerializerMethodField()
+    # ... add 'invoice' to Meta.fields ...
+
+    def get_invoice(self, obj):
+        claims = self.context.get('invoice_claims')
+        if not claims:
+            return None
+        ref = claims.get(('task', obj.pk))
+        if not ref:
+            return None
+        return {'id': ref['invoice_id'], 'number': ref['invoice_number']}
+```
+
+In `apps/api/inventory/serializers.py` `MaterialSerializer`, add the same field with `('material', obj.pk)` and add `'invoice'` to `Meta.fields`:
+
+```python
+    invoice = serializers.SerializerMethodField()
+    # ... add 'invoice' to Meta.fields ...
+
+    def get_invoice(self, obj):
+        claims = self.context.get('invoice_claims')
+        if not claims:
+            return None
+        ref = claims.get(('material', obj.pk))
+        if not ref:
+            return None
+        return {'id': ref['invoice_id'], 'number': ref['invoice_number']}
+```
+
+- [ ] **Step 4: Build the claim map once in `JobSerializer` and pass via context (detail only)**
+
+In `apps/api/jobs/serializers.py`, add a memoized helper and thread context into the two method fields:
+
+```python
+    def _invoice_claims(self, obj):
+        view = self.context.get('view')
+        if view is not None and getattr(view, 'action', None) == 'list':
+            return {}
+        cache = getattr(self, '_claims_cache', None)
+        if cache is None:
+            cache = {}
+            self._claims_cache = cache
+        if obj.pk not in cache:
+            from apps.invoicing.claims import InvoiceClaimService
+            cache[obj.pk] = InvoiceClaimService.claims_for_job(obj)
+        return cache[obj.pk]
+
+    def get_tasks(self, obj):
+        from apps.api.tasks.serializers import TaskSerializer
+        tasks = obj.tasks.all()
+        if not hasattr(obj, '_prefetched_objects_cache') or 'tasks' not in obj._prefetched_objects_cache:
+            tasks = tasks.order_by('sort_order')
+        return TaskSerializer(
+            tasks, many=True,
+            context={**self.context, 'invoice_claims': self._invoice_claims(obj)},
+        ).data
+
+    def get_materials(self, obj):
+        from apps.api.inventory.serializers import MaterialSerializer
+        materials = obj.materials.all()
+        if not hasattr(obj, '_prefetched_objects_cache') or 'materials' not in obj._prefetched_objects_cache:
+            materials = materials.order_by('pk')
+        return MaterialSerializer(
+            materials, many=True,
+            context={**self.context, 'invoice_claims': self._invoice_claims(obj)},
+        ).data
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python manage.py test tests.test_api_jobs -v 2`
+Expected: PASS.
+
+- [ ] **Step 6: Add an N+1 guard test**
+
+```python
+def test_job_detail_invoice_claims_single_query(self):
+    # multiple invoiced tasks/materials must not scale queries with atom count
+    self.client.force_login(self.user)
+    with self.assertNumQueries(self._expected_job_detail_query_count):
+        self.client.get(f'/api/jobs/{self.job.pk}/')
+```
+
+> Determine `_expected_job_detail_query_count` empirically: run once, read the count from the failure message, pin it, and assert it does **not** increase when you add a second invoiced atom in the same test. The point is to lock that claims are one query regardless of atom count.
+
+- [ ] **Step 7: Run and commit**
+
+Run: `python manage.py test tests.test_api_jobs -v 2`
+Expected: PASS.
+
+```bash
+git add apps/api/jobs/serializers.py apps/api/tasks/serializers.py apps/api/inventory/serializers.py tests/test_api_jobs.py
+git commit -m "feat(api): expose per-atom invoice ref on task/material serializers (no N+1)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: `invoice` field on Expense serializer (loose expenses)
+
+**Files:**
+- Modify: `apps/api/expenses/serializers.py` (`ExpenseSerializer`)
+- Modify: `apps/api/expenses/views.py` (`ExpenseViewSet` — provide `invoice_claims` context for the page)
+- Test: `tests/test_api_expenses.py`
+
+**Interfaces:**
+- Consumes: `InvoiceClaimService.claims_for_atoms('expense', pks)` (Task 1).
+- Produces: expense list/detail rows carry `invoice` = `null` or `{id, number}`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_api_expenses.py — reuse the module's expense + invoice builders
+def test_expense_list_marks_invoiced_expense(self):
+    exp = self._make_loose_expense(self.job)         # material-less
+    self._invoice_expense(exp)                        # add helper: line+source type 'expense'
+    self.client.force_login(self.user)
+    resp = self.client.get(f'/api/expenses/?job={self.job.pk}')
+    row = next(r for r in resp.json()['results'] if r['id'] == exp.pk)
+    self.assertEqual(set(row['invoice'].keys()), {'id', 'number'})
+```
+
+> Match the module's pagination shape (`results` vs bare list). `_invoice_expense` mirrors Task 4's `_invoice_material` but with `source_type=InvoiceLineItemSource.SOURCE_EXPENSE` and `source_pk=exp.pk`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python manage.py test tests.test_api_expenses -v 2`
+Expected: FAIL — `KeyError: 'invoice'`.
+
+- [ ] **Step 3: Add the field to `ExpenseSerializer`**
+
+In `apps/api/expenses/serializers.py`, add to `ExpenseSerializer` and to `Meta.fields` (+ `read_only_fields`):
+
+```python
+    invoice = serializers.SerializerMethodField()
+
+    def get_invoice(self, obj):
+        claims = self.context.get('invoice_claims')
+        if not claims:
+            return None
+        ref = claims.get(('expense', obj.pk))
+        if not ref:
+            return None
+        return {'id': ref['invoice_id'], 'number': ref['invoice_number']}
+```
+
+- [ ] **Step 4: Provide the context map in `ExpenseViewSet`**
+
+In `apps/api/expenses/views.py`, override `list` and `retrieve` to inject a page-scoped claim map (one query for the page):
+
+```python
+    def _claims_context_for(self, expenses):
+        from apps.invoicing.claims import InvoiceClaimService
+        pks = [e.pk for e in expenses]
+        return InvoiceClaimService.claims_for_atoms('expense', pks)
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)
+        objs = page if page is not None else list(queryset)
+        ctx = {**self.get_serializer_context(),
+               'invoice_claims': self._claims_context_for(objs)}
+        serializer = self.get_serializer(objs, many=True, context=ctx)
+        if page is not None:
+            return self.get_paginated_response(serializer.data)
+        return Response(serializer.data)
+
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        ctx = {**self.get_serializer_context(),
+               'invoice_claims': self._claims_context_for([instance])}
+        return Response(self.get_serializer(instance, context=ctx).data)
+```
+
+> `Response` is already imported in this module (`apps/api/expenses/views.py:3`). `get_serializer` honors a passed `context` kwarg in DRF.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python manage.py test tests.test_api_expenses -v 2`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/expenses/serializers.py apps/api/expenses/views.py tests/test_api_expenses.py
+git commit -m "feat(api): expose invoice ref on expenses (page-scoped claim map)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Overview UI — "Invoiced" link on tasks, materials, loose expenses
+
+**Files:**
+- Modify: `frontend/src/components/jobs/JobDetail.svelte` (Tasks pillar ~`:829`, Materials & Expenses pillar ~`:948-1040`)
+- Test: `frontend/tests/JobDetail.invoiced.test.js` (new)
+
+**Interfaces:**
+- Consumes: `task.invoice`, `mat.invoice`, `exp.invoice` (`{id, number}` or `null`) from Tasks 6–7.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// frontend/tests/JobDetail.invoiced.test.js
+import { render } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import JobDetail from '../src/components/jobs/JobDetail.svelte';
+
+// Follow docs/designs/frontend-testing.md for the standard JobDetail mount
+// (props it requires: job, expenses, etc. — mirror an existing JobDetail test).
+function baseJob(overrides = {}) {
+  return {
+    job_id: 1, job_number: 'JOB-1', name: 'J', status: 'in_progress',
+    tasks: [], materials: [], ...overrides,
+  };
+}
+
+describe('JobDetail invoiced indicator', () => {
+  it('renders an Invoiced link on an invoiced task', () => {
+    const job = baseJob({
+      tasks: [{ task_id: 7, name: 'Cut', status: 'complete',
+                invoice: { id: 3, number: 'INV-3' } }],
+    });
+    const { getByText } = render(JobDetail, { props: { job, expenses: [] } });
+    const link = getByText(/INV-3/);
+    expect(link.getAttribute('href')).toBe('#/invoices/3');
+  });
+
+  it('omits the link when task.invoice is null', () => {
+    const job = baseJob({
+      tasks: [{ task_id: 7, name: 'Cut', status: 'complete', invoice: null }],
+    });
+    const { queryByText } = render(JobDetail, { props: { job, expenses: [] } });
+    expect(queryByText(/Invoiced/)).toBeNull();
+  });
+});
+```
+
+> Before writing, open an existing `frontend/tests/*JobDetail*` test (if any) and copy its exact mount/props setup; `JobDetail.svelte` takes many props. Adjust `baseJob` to satisfy required props so it renders.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `frontend/`): `npm run test:run -- JobDetail.invoiced`
+Expected: FAIL — no INV-3 link.
+
+- [ ] **Step 3: Implement a small snippet and use it in all three rows**
+
+In `frontend/src/components/jobs/JobDetail.svelte`, add a reusable markup snippet near the top of the markup section:
+
+```svelte
+{#snippet invoicedLink(inv)}
+  {#if inv}
+    <a class="badge-invoiced" href={`#/invoices/${inv.id}`} use:link
+       title="Billed on this invoice">Invoiced · {inv.number}</a>
+  {/if}
+{/snippet}
+```
+
+Render it in the Tasks pillar row (alongside the task name/status), in the material row (near the existing `badge-paid` at `:987`), and in the loose-expense row (near the `expense` badge at `:1029`):
+
+```svelte
+{@render invoicedLink(task.invoice)}
+{@render invoicedLink(mat.invoice)}
+{@render invoicedLink(exp.invoice)}
+```
+
+Add a minimal style consistent with the existing badges:
+
+```svelte
+<style>
+  .badge-invoiced { font-size: 0.85em; text-decoration: none; border: 1px solid #888;
+                    border-radius: 3px; padding: 0 4px; margin-left: 6px; }
+</style>
+```
+
+> Verify `link` is imported from `svelte-spa-router` in this file (it uses hash routing); if not, add `import { link } from 'svelte-spa-router';`. Match the existing badge class names/placement so it reads consistently.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run (from `frontend/`): `npm run test:run -- JobDetail.invoiced`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/jobs/JobDetail.svelte frontend/tests/JobDetail.invoiced.test.js
+git commit -m "feat(ui): show Invoiced link on overview tasks, materials, loose expenses
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Wizard pool — render greyed `not_billable` atoms
+
+**Files:**
+- Modify: `frontend/src/components/invoices/WizardSourcePool.svelte` (`:26-35`) and its atom child component
+- Test: `frontend/tests/WizardSourcePool.test.js` (new or extended)
+
+**Interfaces:**
+- Consumes: `atom.state === 'not_billable'` and `atom.not_billable_reason` from Task 5.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// frontend/tests/WizardSourcePool.test.js
+import { render } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import WizardSourcePool from '../src/components/invoices/WizardSourcePool.svelte';
+
+const pool = {
+  tasks: [{
+    task_id: 1, name: 'Cut', has_billable_atoms: true,
+    atoms: [{ type: 'task', id: 1, description: 'Cut (Hourly)', state: 'not_billable',
+              not_billable_reason: 'task_incomplete', amount: '0.00' }],
+  }],
+  loose_materials: [],
+};
+
+describe('WizardSourcePool not_billable', () => {
+  it('renders a non-selectable reason for not_billable atoms', () => {
+    const { getByText, container } = render(WizardSourcePool, { props: { sourcePool: pool } });
+    expect(getByText(/not complete/i)).toBeTruthy();
+    const checkbox = container.querySelector('input[type="checkbox"]');
+    expect(checkbox === null || checkbox.disabled).toBe(true);
+  });
+});
+```
+
+> Mirror the actual pool shape `WizardSourcePool` consumes (check the `{#each}` keys at `:26-35` and the atom child's props). Adjust the fixture to match real field names.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `frontend/`): `npm run test:run -- WizardSourcePool`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the greyed state in the atom component**
+
+In the atom child component (the one rendered at `WizardSourcePool.svelte:32`), handle `state === 'not_billable'` like the existing `claimed_by_other` disabled rendering: render the checkbox disabled and show a reason label:
+
+```svelte
+{#if atom.state === 'not_billable'}
+  <span class="atom-disabled">
+    {atom.description} — {atom.not_billable_reason === 'task_incomplete'
+      ? 'task not complete' : 'not consumed'}
+  </span>
+{:else if atom.state === 'claimed_by_other'}
+  <!-- existing claimed rendering -->
+{:else}
+  <!-- existing selectable rendering -->
+{/if}
+```
+
+Add a muted style mirroring the existing disabled/claimed style.
+
+> Open the atom child component first and follow its exact existing branch structure for `claimed_by_other`; add `not_billable` as a sibling branch so selection logic (`onToggle`) is never wired for it.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run (from `frontend/`): `npm run test:run -- WizardSourcePool`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/invoices/ frontend/tests/WizardSourcePool.test.js
+git commit -m "feat(ui): grey out not-billable atoms in the invoice wizard pool
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Line item table — stacked per-source list
+
+**Files:**
+- Modify: `frontend/src/components/LineItemTable.svelte` (`sourceLabel` `:23-26`, source cell `:61`)
+- Test: `frontend/tests/LineItemTable.test.js` (new or extended)
+
+**Interfaces:**
+- Consumes: `li.sources[*]` = `{source_type, source_pk, description, computed_amount}` (already serialized for both invoices and estimates).
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// frontend/tests/LineItemTable.test.js
+import { render } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import LineItemTable from '../src/components/LineItemTable.svelte';
+
+const lineItems = [{
+  line_item_id: 1, line_number: 1, description: 'Bundle', qty: 1, price: '30.00',
+  units: 'none', accounting_category: null,
+  sources: [
+    { source_type: 'task', source_pk: 5, description: 'Cut (Hourly)', computed_amount: '20.00' },
+    { source_type: 'material', source_pk: 9, description: 'Steel sheet', computed_amount: '10.00' },
+  ],
+}];
+
+describe('LineItemTable source detail', () => {
+  it('lists each source description and amount when showSource', () => {
+    const { getByText } = render(LineItemTable, { props: { lineItems, showSource: true } });
+    expect(getByText(/Cut \(Hourly\)/)).toBeTruthy();
+    expect(getByText(/Steel sheet/)).toBeTruthy();
+    expect(getByText(/\$10\.00/)).toBeTruthy();
+  });
+
+  it('shows "No source" for a line with no sources', () => {
+    const bare = [{ ...lineItems[0], sources: [], inventory_item: null }];
+    const { getByText } = render(LineItemTable, { props: { lineItems: bare, showSource: true } });
+    expect(getByText('No source')).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `frontend/`): `npm run test:run -- LineItemTable`
+Expected: FAIL — only "2 atoms" rendered.
+
+- [ ] **Step 3: Implement the stacked list**
+
+In `frontend/src/components/LineItemTable.svelte`, replace the `sourceLabel` count usage in the Source cell (`:61`) with a stacked list, keeping the `inventory_item` / `No source` fallbacks:
+
+```svelte
+{#if showSource}
+  <td>
+    {#if li.sources?.length}
+      <ul class="source-list">
+        {#each li.sources as s (s.source_type + ':' + s.source_pk)}
+          <li>{s.description} <span class="src-amt">{fmtMoney(s.computed_amount)}</span></li>
+        {/each}
+      </ul>
+    {:else if li.inventory_item}
+      PLI #{li.inventory_item}
+    {:else}
+      No source
+    {/if}
+  </td>
+{/if}
+```
+
+Add styles:
+
+```svelte
+<style>
+  .source-list { margin: 0; padding-left: 1em; list-style: disc; }
+  .source-list li { font-size: 0.9em; }
+  .src-amt { color: #555; }
+</style>
+```
+
+> Keep `sourceLabel` only if still used elsewhere; otherwise remove it. `fmtMoney` already exists in this file (`:15`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run (from `frontend/`): `npm run test:run -- LineItemTable`
+Expected: PASS. Then run the full frontend suite for regressions (invoice + estimate detail render this component):
+Run (from `frontend/`): `npm run test:run`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/LineItemTable.svelte frontend/tests/LineItemTable.test.js
+git commit -m "feat(ui): show stacked per-source list on invoice/estimate line items
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Docs + LATER note
+
+**Files:**
+- Modify: `docs/designs/invoicing-and-expenses.md`, `docs/designs/estimates-and-prices.md`, `docs/designs/jobs-tasks-and-worksheets.md`, `docs/designs/materials-inventory-and-purchasing.md`
+- Modify: `docs/designs/LATER.md`
+
+- [ ] **Step 1: Update the design docs**
+
+Document, in the relevant doc each: the `InvoiceClaimService` predicate and the binary "invoiced" indicator; task freeze-on-complete (incl. no bleps, `sort_order` exempt); material invoice freeze (sell_price, unconsume); wizard billability gates (task complete / material consumed / expense always); the stacked per-source line-item display.
+
+- [ ] **Step 2: Add the expense-freeze symmetry note to LATER**
+
+Append to `docs/designs/LATER.md`:
+
+```markdown
+- Expense atoms have an invoice-freeze (ExpenseService) but no separate
+  billability-readiness gate (they bill on submission, by design). Revisit only
+  if a "not ready to bill" expense state is ever needed.
+```
+
+> (Per the design, expenses are fully in scope and already frozen; this note records the deliberate absence of a readiness gate, not missing work.)
+
+- [ ] **Step 3: Run the whole backend + frontend suite once**
+
+Run: `python manage.py test` (single process)
+Run (from `frontend/`): `npm run test:run`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/designs/
+git commit -m "docs: invoiced-atom visibility + freeze across design docs
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Part 1 (centralized predicate) → Task 1.
+- Part 2 (freeze: task / material / expense) → Tasks 2, 3, 4 (expense already done; refactor in Task 1).
+- Part 3 (wizard billability gates) → Task 5.
+- Part 4 (indicator API) → Tasks 6, 7.
+- Part 5 (overview UI) → Task 8.
+- Part 6 (stacked per-source list) → Task 10.
+- Wizard greyed state (from Part 3 UI) → Task 9.
+- Docs + LATER → Task 11.
+
+**Type consistency:** context key `invoice_claims` and tuple key `(source_type, source_pk)` used identically in Tasks 1, 6, 7. `invoice` field shape `{id, number}` identical across task/material/expense serializers and the frontend (`inv.id`, `inv.number`). `not_billable` / `not_billable_reason` (`'task_incomplete'`/`'material_unconsumed'`) consistent between Task 5 (backend) and Task 9 (frontend).
+
+**Known verification points for the implementer** (resolve by reading the cited code, not by guessing):
+- Reuse each test module's existing builders/helpers; do not invent model fields (esp. how `Invoice`/`InvoiceLineItem`/`Task`/`Material` are constructed in `tests/test_api_invoicing.py`).
+- Confirm `ValidationError` imports already present in each service module before adding code.
+- Confirm `svelte-spa-router`'s `link` import in `JobDetail.svelte`; confirm the atom child component path used by `WizardSourcePool`.
+- Pin the N+1 query count (Task 6 Step 6) empirically.

--- a/frontend/src/components/LineItemTable.svelte
+++ b/frontend/src/components/LineItemTable.svelte
@@ -20,11 +20,6 @@
     if (!c) return '—';
     return c.taxable ? 'Yes' : 'No';
   }
-  function sourceLabel(li) {
-    if (li.sources?.length) return `${li.sources.length} atom${li.sources.length === 1 ? '' : 's'}`;
-    if (li.inventory_item) return `PLI #${li.inventory_item}`;
-    return 'No source';
-  }
 
   let subtotal = $derived(
     (lineItems || []).reduce((s, li) => s + lineTotal(li), 0)
@@ -58,7 +53,21 @@
           <td>{categoryName(li.accounting_category)}</td>
           <td>{categoryTaxable(li.accounting_category)}</td>
           <td class="preserve-breaks"><LinkifiedText text={li.description || 'No description'} /></td>
-          {#if showSource}<td>{sourceLabel(li)}</td>{/if}
+          {#if showSource}
+            <td>
+              {#if li.sources?.length}
+                <ul class="source-list">
+                  {#each li.sources as s (s.source_type + ':' + s.source_pk)}
+                    <li>{s.description} <span class="src-amt">{fmtMoney(s.computed_amount)}</span></li>
+                  {/each}
+                </ul>
+              {:else if li.inventory_item}
+                PLI #{li.inventory_item}
+              {:else}
+                No source
+              {/if}
+            </td>
+          {/if}
           <td>{li.qty}</td>
           <td>{li.units || '—'}</td>
           <td>{fmtMoney(li.price)}</td>
@@ -89,4 +98,7 @@
   .line-items-table th, .line-items-table td { padding: 6px 10px; }
   .subtotal-row { background-color: #f5f5f5; }
   .total-row { background-color: #e8e8e8; }
+  .source-list { margin: 0; padding-left: 1em; list-style: disc; }
+  .source-list li { font-size: 0.9em; }
+  .src-amt { color: #555; }
 </style>

--- a/frontend/src/components/TaskTree.svelte
+++ b/frontend/src/components/TaskTree.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { link } from 'svelte-spa-router';
   import { formatQtyUnits } from '../lib/format.js';
   import TaskActivityIndicator from './tasks/TaskActivityIndicator.svelte';
 
@@ -175,6 +176,11 @@
   </tr>
 {/snippet}
 
+{#snippet invoicedLink(inv)}
+  <a class="badge-invoiced" href={`#/invoices/${inv.id}`} use:link
+     title="Billed on this invoice">INVOICED</a>
+{/snippet}
+
 <table class="data-table task-tree-table">
   <thead>
     <tr>
@@ -204,7 +210,7 @@
         </td>
         {#if showAssignee}<td>{task.assignee_name || 'Unassigned'} {#if !readonly && !isTerminal(task) && canManage}<button type="button" class="small-btn" onclick={() => onAssignTask(task)}>assign</button>{/if}</td>{/if}
         <td class="text-right">{fmtWorkerTime(task.est_worker_time)}</td>
-        {#if showStatus}<td><TaskActivityIndicator {task} />{#if task.status === 'blocked' && task.blocked_reason}<br><span class="blocked-reason preserve-breaks">{task.blocked_reason}</span>{/if}</td>{/if}
+        {#if showStatus}<td>{#if task.invoice}{@render invoicedLink(task.invoice)}{:else}<TaskActivityIndicator {task} />{#if task.status === 'blocked' && task.blocked_reason}<br><span class="blocked-reason preserve-breaks">{task.blocked_reason}</span>{/if}{/if}</td>{/if}
         <td class="text-right">{task.scheme_unit_label || '-'}</td>
         <td class="text-right">{task.est_qty ?? '-'}</td>
         <td class="text-right">{taskActual(task) ?? '-'}</td>
@@ -243,7 +249,7 @@
           </td>
           {#if showAssignee}<td></td>{/if}
           <td></td>
-          {#if showStatus}<td></td>{/if}
+          {#if showStatus}<td>{#if mat.invoice}{@render invoicedLink(mat.invoice)}{/if}</td>{/if}
           <td class="text-right">-</td>
           <td class="text-right">{formatQtyUnits(mat.quantity, mat.units)}</td>
           <td class="text-right">-</td>
@@ -276,7 +282,7 @@
           </td>
           {#if showAssignee}<td>{sub.assignee_name || 'Unassigned'} {#if !readonly && !isTerminal(sub) && canManage}<button type="button" class="small-btn" onclick={() => onAssignTask(sub)}>assign</button>{/if}</td>{/if}
           <td class="text-right">{fmtWorkerTime(sub.est_worker_time)}</td>
-          {#if showStatus}<td><TaskActivityIndicator task={sub} />{#if sub.status === 'blocked' && sub.blocked_reason}<br><span class="blocked-reason preserve-breaks">{sub.blocked_reason}</span>{/if}</td>{/if}
+          {#if showStatus}<td>{#if sub.invoice}{@render invoicedLink(sub.invoice)}{:else}<TaskActivityIndicator task={sub} />{#if sub.status === 'blocked' && sub.blocked_reason}<br><span class="blocked-reason preserve-breaks">{sub.blocked_reason}</span>{/if}{/if}</td>{/if}
           <td class="text-right">{sub.scheme_unit_label || '-'}</td>
           <td class="text-right">{sub.est_qty ?? '-'}</td>
           <td class="text-right">{taskActual(sub) ?? '-'}</td>
@@ -310,7 +316,7 @@
             </td>
             {#if showAssignee}<td></td>{/if}
             <td></td>
-            {#if showStatus}<td></td>{/if}
+            {#if showStatus}<td>{#if mat.invoice}{@render invoicedLink(mat.invoice)}{/if}</td>{/if}
             <td class="text-right">-</td>
             <td class="text-right">{formatQtyUnits(mat.quantity, mat.units)}</td>
             <td class="text-right">-</td>
@@ -347,7 +353,7 @@
           </td>
           {#if showAssignee}<td></td>{/if}
           <td></td>
-          {#if showStatus}<td></td>{/if}
+          {#if showStatus}<td>{#if mat.invoice}{@render invoicedLink(mat.invoice)}{/if}</td>{/if}
           <td class="text-right">-</td>
           <td class="text-right">{formatQtyUnits(mat.quantity, mat.units)}</td>
           <td class="text-right">-</td>
@@ -403,6 +409,11 @@
   .move-cell { text-align: center; width: 40px; }
   .material-marker { color: #aaa; font-size: 8px; vertical-align: middle; margin-right: 4px; }
   .inv-badge { margin-left: 6px; font-size: 11px; }
+  .badge-invoiced {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.3px; color: #047857; text-decoration: none;
+  }
+  .badge-invoiced:hover { text-decoration: underline; }
 
   /* Top-level task rows use the shared .data-table zebra stripe. */
   .subtask-row { background: #f0f9ff; }

--- a/frontend/src/components/jobs/JobDetail.svelte
+++ b/frontend/src/components/jobs/JobDetail.svelte
@@ -517,6 +517,13 @@
 
 <div class="job-detail-page">
 
+{#snippet invoicedLink(inv)}
+  {#if inv}
+    <a class="badge-invoiced" href={`#/invoices/${inv.id}`} use:link
+       title="Billed on this invoice">Invoiced · {inv.number}</a>
+  {/if}
+{/snippet}
+
 <JobHeader {job} {contact} {onStatusChange} />
 
 {#if job.status === 'draft' && job.latest_change_request}
@@ -871,7 +878,7 @@
             <tbody>
               {#each jobTasks as task}
                 <tr class:row-active={task.status === 'in_progress'}>
-                  <td><a href="#/jobs/{job.job_id}/tasks/{task.task_id}">{task.name}</a></td>
+                  <td><a href="#/jobs/{job.job_id}/tasks/{task.task_id}">{task.name}</a>{@render invoicedLink(task.invoice)}</td>
                   <td class="assigned">{task.assignee_name || '—'}</td>
                   <td class="text-center"><TaskActivityIndicator {task} />{#if task.status === 'blocked' && task.blocked_reason}<br><small class="preserve-breaks">{task.blocked_reason}</small>{/if}</td>
                   <td class="time-cell">
@@ -985,6 +992,7 @@
                     <span class="preserve-breaks">{mat.description || '(no description)'}</span>
                     {#if consumed}<span class="badge-consumed">consumed</span>{/if}
                     {#if expenseByMaterial[mat.material_id]}<span class="badge-paid">paid {money(expenseByMaterial[mat.material_id].amount)}</span>{/if}
+                    {@render invoicedLink(mat.invoice)}
                     {#if needsMore && canManageFinancials}
                       <a class="add-po" href="#/purchase-orders/new?job={job.job_id}&material={mat.material_id}">order</a>
                     {/if}
@@ -1027,6 +1035,7 @@
                   <td>
                     <span class="preserve-breaks">{exp.description || '(expense)'}</span>
                     <span class="badge-paid">expense</span>
+                    {@render invoicedLink(exp.invoice)}
                   </td>
                   <td>{exp.accounting_category_name || '—'}</td>
                   <td class="text-right">{money(exp.amount)}</td>
@@ -1789,6 +1798,11 @@
     font-size: 10px; color: #166534;
     margin-left: 6px; padding: 1px 6px;
     background: #dcfce7; border-radius: 8px;
+  }
+  .badge-invoiced {
+    font-size: 0.85em; text-decoration: none;
+    border: 1px solid #888; border-radius: 3px;
+    padding: 0 4px; margin-left: 6px;
   }
   .mat-table .add-po {
     font-size: 11px; color: #1e40af; margin-left: 8px;

--- a/frontend/src/components/wizards/WizardAtomRow.svelte
+++ b/frontend/src/components/wizards/WizardAtomRow.svelte
@@ -12,7 +12,11 @@
   }
 </script>
 
-{#if atom.state === 'available'}
+{#if atom.state === 'not_billable'}
+  <span class="atom-not-billable">
+    {atom.description} — {atom.not_billable_reason === 'task_incomplete' ? 'task not complete' : 'not consumed'}
+  </span>
+{:else if atom.state === 'available'}
   <label>
     <input type="checkbox" checked={selected} onchange={onToggle}>
     <small>[{atom.type === 'task' || atom.type === 'plan_task' ? 'task' : atom.type === 'expense' ? 'expense' : 'material'}]</small>
@@ -37,3 +41,12 @@
     {/if}
   </span>
 {/if}
+
+<style>
+  .atom-not-billable {
+    color: #aaa;
+    font-style: italic;
+    cursor: default;
+    user-select: none;
+  }
+</style>

--- a/frontend/src/routes/expenses/ExpenseListPage.svelte
+++ b/frontend/src/routes/expenses/ExpenseListPage.svelte
@@ -85,6 +85,11 @@
 
 <h2>Expenses</h2>
 
+{#snippet invoicedLink(inv)}
+  <a class="badge-invoiced" href={`#/invoices/${inv.id}`} use:link
+     title="Billed on this invoice">INVOICED · {inv.number}</a>
+{/snippet}
+
 {#if outstanding.length > 0}
   <section style="border: 1px solid #4a90e2; padding: 10px; margin-bottom: 12px">
     <h3 style="margin-top: 0">Outstanding reimbursements</h3>
@@ -195,16 +200,30 @@
             {#if e.status === 'sync_failed'}
               <button type="button" onclick={() => retryPush(e)}>retry</button>
             {/if}
+            {#if e.invoice}<br>{@render invoicedLink(e.invoice)}{/if}
           </td>
           <td>
-            <button type="button" onclick={() => editExpense(e)}>edit</button>
-            {#if e.payment_method === 'personal' && e.status === 'submitted'}
-              <button type="button" onclick={() => rejectExpense(e)}>reject</button>
+            {#if e.invoice}
+              <span class="locked-note">billed — locked</span>
+            {:else}
+              <button type="button" onclick={() => editExpense(e)}>edit</button>
+              {#if e.payment_method === 'personal' && e.status === 'submitted'}
+                <button type="button" onclick={() => rejectExpense(e)}>reject</button>
+              {/if}
+              <button type="button" onclick={() => deleteExpense(e)}>delete</button>
             {/if}
-            <button type="button" onclick={() => deleteExpense(e)}>delete</button>
           </td>
         </tr>
       {/each}
     </tbody>
   </table>
 {/if}
+
+<style>
+  .badge-invoiced {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.3px; color: #047857; text-decoration: none;
+  }
+  .badge-invoiced:hover { text-decoration: underline; }
+  .locked-note { font-size: 11px; color: #888; font-style: italic; }
+</style>

--- a/frontend/src/routes/invoices/InvoiceWizardPage.svelte
+++ b/frontend/src/routes/invoices/InvoiceWizardPage.svelte
@@ -125,7 +125,11 @@
     }
     for (const task of sourcePool.tasks) {
       for (const atom of task.atoms) {
-        if (atom.state === 'claimed_by_other') continue;
+        // Both claimed_by_other (another invoice) and not_billable (task not
+        // complete / material not consumed) are properties the backend decides
+        // independently of THIS invoice's line items — never reconcile them to
+        // 'available', or the wizard would offer un-billable atoms.
+        if (atom.state === 'claimed_by_other' || atom.state === 'not_billable') continue;
         const key = `${atom.type}:${atom.id}`;
         if (claimMap.has(key)) {
           const claim = claimMap.get(key);

--- a/frontend/src/routes/jobs/TaskDetailPage.svelte
+++ b/frontend/src/routes/jobs/TaskDetailPage.svelte
@@ -334,9 +334,14 @@
     onCancel={handleCancel}
   />
 
+  {#snippet invoicedLink(inv)}
+    <a class="badge-invoiced" href={`#/invoices/${inv.id}`} use:link
+       title="Billed on this invoice">INVOICED</a>
+  {/snippet}
+
   <table class="data-table">
     <tbody>
-      <tr><td>Status</td><td><TaskActivityIndicator {task} />{#if task.status === 'blocked' && task.blocked_reason} — {task.blocked_reason}{/if}</td></tr>
+      <tr><td>Status</td><td>{#if task.invoice}{@render invoicedLink(task.invoice)}{:else}<TaskActivityIndicator {task} />{#if task.status === 'blocked' && task.blocked_reason} — {task.blocked_reason}{/if}{/if}</td></tr>
       <tr><td>Description</td><td class="preserve-breaks"><LinkifiedText text={task.description || '-'} /></td></tr>
       <tr><td>Assignee</td><td>{task.assignee_name || 'Unassigned'} {#if task?.can_manage}<button type="button" onclick={() => { assignModalOpen = true; }}>assign</button>{/if}</td></tr>
       <tr><td>Est. quantity</td><td>{task.est_qty || '-'} {task.scheme_unit_label || ''}</td></tr>
@@ -398,7 +403,7 @@
       <tbody>
         {#each materials as mat}
           <tr>
-            <td class="preserve-breaks">{mat.description || '(no description)'}</td>
+            <td class="preserve-breaks">{mat.description || '(no description)'}{#if mat.invoice} {@render invoicedLink(mat.invoice)}{/if}</td>
             <td class="text-right">{formatQtyUnits(mat.quantity, mat.units)}</td>
             <td class="text-right">{mat.unit_cost ? `$${Number(mat.unit_cost).toFixed(2)}` : '-'}</td>
             <td class="text-right">{mat.sell_price ? `$${Number(mat.sell_price).toFixed(2)}` : '-'}</td>
@@ -526,4 +531,9 @@
     cursor: pointer; border: 1px solid #ccc; background: #fff; border-radius: 3px;
   }
   .materials-table button:hover { background: #f0f0f0; }
+  .badge-invoiced {
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.3px; color: #047857; text-decoration: none;
+  }
+  .badge-invoiced:hover { text-decoration: underline; }
 </style>

--- a/frontend/tests/LineItemTable.test.js
+++ b/frontend/tests/LineItemTable.test.js
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import LineItemTable from '../src/components/LineItemTable.svelte';
+
+const lineItems = [{
+  line_item_id: 1, line_number: 1, description: 'Bundle', qty: 1, price: '30.00',
+  units: 'none', accounting_category: null,
+  sources: [
+    { source_type: 'task', source_pk: 5, description: 'Cut (Hourly)', computed_amount: '20.00' },
+    { source_type: 'material', source_pk: 9, description: 'Steel sheet', computed_amount: '10.00' },
+  ],
+}];
+
+describe('LineItemTable source detail', () => {
+  it('lists each source description and amount when showSource', () => {
+    const { getByText } = render(LineItemTable, { props: { lineItems, showSource: true } });
+    expect(getByText(/Cut \(Hourly\)/)).toBeTruthy();
+    expect(getByText(/Steel sheet/)).toBeTruthy();
+    expect(getByText(/\$10\.00/)).toBeTruthy();
+  });
+
+  it('shows "No source" for a line with no sources', () => {
+    const bare = [{ ...lineItems[0], sources: [], inventory_item: null }];
+    const { getByText } = render(LineItemTable, { props: { lineItems: bare, showSource: true } });
+    expect(getByText('No source')).toBeTruthy();
+  });
+});

--- a/frontend/tests/components/TaskTree.test.js
+++ b/frontend/tests/components/TaskTree.test.js
@@ -129,4 +129,32 @@ describe('TaskTree', () => {
     expect(queryByRole('button', { name: 'assign' })).toBeNull();
     expect(queryByRole('button', { name: 'cancel' })).toBeNull();
   });
+
+  it('shows an INVOICED link instead of the status indicator on an invoiced task', () => {
+    const t = task({ status: 'complete', invoice: { id: 7, number: 'INV-7' } });
+    const { getByRole, queryByText } = render(TaskTree, { props: { tasks: [t] } });
+    const link = getByRole('link', { name: 'INVOICED' });
+    expect(link.getAttribute('href')).toBe('#/invoices/7');
+    // The normal status label ("Complete") is replaced, not shown alongside.
+    expect(queryByText('Complete')).toBeNull();
+  });
+
+  it('shows the status indicator (no INVOICED link) on an uninvoiced complete task', () => {
+    const t = task({ status: 'complete', invoice: null });
+    const { queryByRole, getByText } = render(TaskTree, { props: { tasks: [t] } });
+    expect(queryByRole('link', { name: 'INVOICED' })).toBeNull();
+    expect(getByText('Complete')).toBeInTheDocument();
+  });
+
+  it('shows an INVOICED link in the status column of an invoiced material', () => {
+    const t = task({
+      materials: [{
+        material_id: 9, description: 'Steel', quantity: '3', sell_price: '5',
+        units: 'kg', consumption_state: 'consumed', invoice: { id: 4, number: 'INV-4' },
+      }],
+    });
+    const { getByRole } = render(TaskTree, { props: { tasks: [t] } });
+    const link = getByRole('link', { name: 'INVOICED' });
+    expect(link.getAttribute('href')).toBe('#/invoices/4');
+  });
 });

--- a/frontend/tests/components/invoices/InvoiceWizardPage.notbillable.test.js
+++ b/frontend/tests/components/invoices/InvoiceWizardPage.notbillable.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+
+// Mock the API the page loads from. Static imports below share one Svelte
+// runtime with testing-library (no vi.resetModules — that would give the
+// component a second Svelte instance and trigger effect_orphan).
+vi.mock('@/lib/api.js', () => ({
+  api: { get: vi.fn(), post: vi.fn(), delete: vi.fn() },
+}));
+
+import { api } from '@/lib/api.js';
+import InvoiceWizardPage from '@/routes/invoices/InvoiceWizardPage.svelte';
+
+const POOL = {
+  tasks: [
+    {
+      task_id: 5,
+      name: 'Cut',
+      has_billable_atoms: true,
+      atoms: [
+        {
+          type: 'task',
+          id: 5,
+          description: 'Cut (Hourly)',
+          state: 'not_billable',
+          not_billable_reason: 'task_incomplete',
+          qty: '1',
+          rate: '0.00',
+          units: 'none',
+          amount: '0.00',
+          claiming_line_item_id: null,
+          claiming_line_number: null,
+          claiming_invoice_id: null,
+          claiming_invoice_number: null,
+        },
+      ],
+    },
+  ],
+};
+
+beforeEach(() => {
+  api.get.mockReset();
+  api.get.mockImplementation((url) => {
+    if (url === '/api/invoices/1/') {
+      // job: null so the page skips the job/contact fetches entirely.
+      return Promise.resolve({ invoice_id: 1, job: null, status: 'draft' });
+    }
+    if (url === '/api/invoices/1/line-items/') return Promise.resolve([]);
+    if (url === '/api/invoices/1/source-pool/') return Promise.resolve(POOL);
+    return Promise.resolve(null);
+  });
+});
+
+describe('InvoiceWizardPage — not_billable atoms survive reconcile', () => {
+  it('keeps an incomplete-task atom non-selectable after load (no checkbox)', async () => {
+    render(InvoiceWizardPage, { props: { params: { id: '1' } } });
+
+    // Wait for the async load + reconcile to settle: the atom's description renders.
+    await screen.findByText(/Cut \(Hourly\)/);
+
+    // The greyed reason must be shown…
+    expect(screen.getByText(/task not complete/i)).toBeTruthy();
+    // …and there must be NO selectable checkbox for it. Before the fix,
+    // reconcileAtomStates() clobbered state 'not_billable' → 'available',
+    // which renders an enabled checkbox.
+    expect(screen.queryByRole('checkbox')).toBeNull();
+  });
+});

--- a/frontend/tests/components/invoices/WizardSourcePool.test.js
+++ b/frontend/tests/components/invoices/WizardSourcePool.test.js
@@ -68,4 +68,40 @@ describe('invoices/WizardSourcePool', () => {
     await fireEvent.click(checkbox);
     expect(checkbox).toBeChecked();
   });
+
+  it('shows a non-selectable reason label for a not_billable task atom (task_incomplete)', () => {
+    const { getByText, container } = render(WizardSourcePool, {
+      props: {
+        sourcePool: {
+          tasks: [{
+            task_id: 1, name: 'Cut', has_billable_atoms: true,
+            atoms: [{ type: 'task', id: 1, description: 'Cut (Hourly)',
+                      qty: 0, rate: '0.00', amount: '0.00', units: 'none',
+                      state: 'not_billable', not_billable_reason: 'task_incomplete' }],
+          }],
+        },
+      },
+    });
+    expect(getByText(/not complete/i)).toBeTruthy();
+    const checkbox = container.querySelector('input[type="checkbox"]');
+    expect(checkbox === null || checkbox.disabled).toBe(true);
+  });
+
+  it('shows a non-selectable reason label for a not_billable material atom (material_unconsumed)', () => {
+    const { getByText, container } = render(WizardSourcePool, {
+      props: {
+        sourcePool: {
+          tasks: [{
+            task_id: 2, name: 'Prep', has_billable_atoms: true,
+            atoms: [{ type: 'material', id: 7, description: 'Steel rod',
+                      qty: 0, rate: '0.00', amount: '0.00', units: 'none',
+                      state: 'not_billable', not_billable_reason: 'material_unconsumed' }],
+          }],
+        },
+      },
+    });
+    expect(getByText(/not consumed/i)).toBeTruthy();
+    const checkbox = container.querySelector('input[type="checkbox"]');
+    expect(checkbox === null || checkbox.disabled).toBe(true);
+  });
 });

--- a/frontend/tests/components/jobs/JobDetail.invoiced.test.js
+++ b/frontend/tests/components/jobs/JobDetail.invoiced.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+
+vi.mock('@/lib/api.js', () => ({ api: { get: vi.fn(), patch: vi.fn() } }));
+vi.mock('svelte-spa-router', () => ({ link: () => ({}) }));
+
+import { api } from '@/lib/api.js';
+import { user } from '@/stores/auth.js';
+import JobDetail from '@/components/jobs/JobDetail.svelte';
+
+beforeEach(() => {
+  api.get.mockReset();
+  api.get.mockResolvedValue([]);
+  user.set({ permissions: [] });
+});
+
+function baseJob(overrides = {}) {
+  return {
+    job_id: 1, job_number: 'JOB-1', name: 'J', status: 'in_progress',
+    tasks: [], materials: [], ...overrides,
+  };
+}
+
+describe('JobDetail invoiced indicator', () => {
+  it('renders an Invoiced link on an invoiced task', () => {
+    const job = baseJob({
+      tasks: [{ task_id: 7, name: 'Cut', status: 'complete',
+                invoice: { id: 3, number: 'INV-3' } }],
+    });
+    const { getByText } = render(JobDetail, { props: { job, expenses: [] } });
+    const link = getByText(/INV-3/);
+    expect(link.getAttribute('href')).toBe('#/invoices/3');
+  });
+
+  it('omits the link when task.invoice is null', () => {
+    const job = baseJob({
+      tasks: [{ task_id: 7, name: 'Cut', status: 'complete', invoice: null }],
+    });
+    const { queryByRole } = render(JobDetail, { props: { job, expenses: [] } });
+    // No <a> element whose accessible name matches "Invoiced" should be present.
+    expect(queryByRole('link', { name: /Invoiced/ })).toBeNull();
+  });
+
+  it('renders an Invoiced link on an invoiced material', async () => {
+    const job = baseJob({
+      materials: [{ material_id: 11, description: 'Steel', quantity: '1',
+                    unit_cost: '10.00', units: 'kg',
+                    consumption_state: 'pending',
+                    invoice: { id: 5, number: 'INV-5' } }],
+    });
+    const { getByText, getByRole } = render(JobDetail, { props: { job, expenses: [] } });
+    // Open the Materials & Expenses section
+    await fireEvent.click(getByText('Materials'));
+    const link = getByText(/INV-5/);
+    expect(link.getAttribute('href')).toBe('#/invoices/5');
+  });
+
+  it('renders an Invoiced link on a loose expense', async () => {
+    const expenses = [
+      { id: 20, amount: '40.00', material: null, description: 'FedEx',
+        accounting_category_name: 'Freight',
+        invoice: { id: 7, number: 'INV-7' } },
+    ];
+    const job = baseJob({ materials: [] });
+    const { getByText } = render(JobDetail, { props: { job, expenses } });
+    // Open the Materials & Expenses section
+    await fireEvent.click(getByText('Materials'));
+    const link = getByText(/INV-7/);
+    expect(link.getAttribute('href')).toBe('#/invoices/7');
+  });
+});

--- a/tests/test_api_bleps.py
+++ b/tests/test_api_bleps.py
@@ -172,6 +172,43 @@ class BlepCreateAPITest(BaseTestCase):
 
 
 from django.contrib.auth.models import Permission
+from django.core.exceptions import ValidationError
+from apps.jobs.services import BlepService
+
+
+class BlepCreateHistoricalCompleteTaskTest(BaseTestCase):
+    """BlepService.create_historical must reject tasks that are already complete."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = User.objects.create_user(username='worker_hist_complete', password='x')
+        self.job = Job.objects.first()
+        for s in (Job.STATUS_SUBMITTED, Job.STATUS_APPROVED):
+            self.job.status = s
+            self.job.save()
+        self.task = Task.objects.create(name='T_hist', job=self.job, rate_scheme_id=1)
+        # Wide closed shift so historical bleps have an enclosing shift.
+        now = timezone.now()
+        Shift.objects.create(
+            user=self.user,
+            start_time=now - timedelta(days=3),
+            end_time=now + timedelta(hours=1),
+        )
+
+    def _recent_start_end(self, hours_ago=2, duration_hours=1):
+        now = timezone.now()
+        start = now - timedelta(hours=hours_ago)
+        end = start + timedelta(hours=duration_hours)
+        return start, end
+
+    def test_create_historical_rejects_complete_task(self):
+        self.task.status = Task.STATUS_COMPLETE
+        self.task.save(update_fields=['status'])
+        start, end = self._recent_start_end()
+        with self.assertRaises(ValidationError):
+            BlepService.create_historical(
+                actor=self.user, task=self.task, start_time=start, end_time=end,
+            )
 
 
 class BlepUpdateAPITest(BaseTestCase):

--- a/tests/test_api_expenses.py
+++ b/tests/test_api_expenses.py
@@ -392,3 +392,86 @@ class ExpenseStockReceiptApiTest(TestCase):
         self.assertFalse(Material.objects.filter(job=self.job).exists())  # no consumable
         self.pli.refresh_from_db()
         self.assertEqual(self.pli.qty_on_hand, Decimal('10.00'))  # 7 + 3
+
+
+class ExpenseInvoiceClaimTest(TestCase):
+    """invoice field on expense list/retrieve rows (Task 7)."""
+
+    def setUp(self):
+        from apps.contacts.models import Contact
+        from apps.jobs.models import Job
+        from apps.core.models import AppState
+        # Seed number generation for Invoice.save() auto-number.
+        Configuration.objects.get_or_create(
+            key='invoice_number_sequence',
+            defaults={'value': 'INV-{year}-{counter:04d}'},
+        )
+        AppState.objects.get_or_create(key='invoice_counter', defaults={'value': '0'})
+        self.client = Client()
+        self.cat = AccountingCategory.objects.create(code='INV', name='Invoiceable')
+        perm = Permission.objects.get(
+            codename='can_manage_financials', content_type__app_label='core',
+        )
+        self.user = User.objects.create_user(username='fin', password='x')
+        self.user.user_permissions.add(perm)
+        self.user = User.objects.get(pk=self.user.pk)
+        self.contact = Contact.objects.create(first_name='T', last_name='C')
+        self.job = Job.objects.create(job_number='JOB-CLAIM-1', contact=self.contact)
+
+    def _make_loose_expense(self, job):
+        """Create a material-less (loose) expense linked to job."""
+        return Expense.objects.create(
+            entered_by=self.user,
+            purchased_by=self.user,
+            amount=Decimal('50.00'),
+            purchased_on=date(2026, 6, 1),
+            accounting_category=self.cat,
+            payment_method=Expense.PAYMENT_METHOD_PERSONAL,
+            job=job,
+        )
+
+    def _invoice_expense(self, exp):
+        """Create an Invoice + InvoiceLineItem + InvoiceLineItemSource for exp."""
+        from apps.invoicing.models import Invoice, InvoiceLineItem, InvoiceLineItemSource
+        inv = Invoice.objects.create(
+            job=exp.job,
+            status=Invoice.STATUS_DRAFT,
+        )
+        li = InvoiceLineItem.objects.create(
+            invoice=inv,
+            description='Expense charge',
+            qty=Decimal('1'),
+            units='none',
+            price=exp.amount,
+        )
+        InvoiceLineItemSource.objects.create(
+            invoice_line_item=li,
+            source_type=InvoiceLineItemSource.SOURCE_EXPENSE,
+            source_pk=exp.pk,
+        )
+        return inv
+
+    def test_expense_list_marks_invoiced_expense(self):
+        exp = self._make_loose_expense(self.job)
+        self._invoice_expense(exp)
+        self.client.force_login(self.user)
+        resp = self.client.get(f'/api/expenses/?job={self.job.pk}')
+        self.assertEqual(resp.status_code, 200)
+        row = next(r for r in resp.json()['results'] if r['id'] == exp.pk)
+        self.assertEqual(set(row['invoice'].keys()), {'id', 'number'})
+
+    def test_expense_list_uninvoiced_has_null_invoice(self):
+        exp = self._make_loose_expense(self.job)
+        self.client.force_login(self.user)
+        resp = self.client.get(f'/api/expenses/?job={self.job.pk}')
+        self.assertEqual(resp.status_code, 200)
+        row = next(r for r in resp.json()['results'] if r['id'] == exp.pk)
+        self.assertIsNone(row['invoice'])
+
+    def test_expense_retrieve_marks_invoiced_expense(self):
+        exp = self._make_loose_expense(self.job)
+        self._invoice_expense(exp)
+        self.client.force_login(self.user)
+        resp = self.client.get(f'/api/expenses/{exp.pk}/')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(set(resp.json()['invoice'].keys()), {'id', 'number'})

--- a/tests/test_api_invoicing.py
+++ b/tests/test_api_invoicing.py
@@ -384,9 +384,63 @@ class BillabilityGateTest(BaseTestCase):
         self.assertIn('not_billable_reason', complete_atom)
         self.assertIsNone(complete_atom['not_billable_reason'])
 
-    def test_incomplete_task_child_material_is_not_billable(self):
-        """Material on an incomplete task is not_billable (unconsumed)."""
+    def test_unconsumed_material_not_billable_regardless_of_parent_task(self):
+        """Material is not_billable because it is unconsumed — not because of
+        the parent task's status.  The pending_material is attached to the
+        incomplete_task, but the gate keys only on its own consumption_state."""
         from apps.invoicing.services import InvoiceWizardService
         pool = InvoiceWizardService.get_source_pool(self.invoice)
         mat_atom = self._find_atom(pool, 'material', self.pending_material.pk)
         self.assertEqual(mat_atom['state'], 'not_billable')
+
+    def test_consumed_material_on_incomplete_task_is_available(self):
+        """Key invariant: a CONSUMED material on an INCOMPLETE task must be
+        'available' in the source pool — the material gate never looks at the
+        parent task's status, only at the material's own consumption_state."""
+        from apps.inventory.models import InventoryItem
+        from apps.invoicing.services import InvoiceWizardService
+
+        pli = InventoryItem.objects.filter(
+            accounting_category=self.cat,
+        ).first()
+        consumed_on_incomplete = Material.objects.create(
+            job=self.job, task=self.incomplete_task,
+            description='Consumed-on-incomplete Ply', quantity=Decimal('3.00'),
+            sell_price=Decimal('10.00'), inventory_item=pli,
+            accounting_category=self.cat,
+        )
+        consumed_on_incomplete.consumption_state = Material.CONSUMPTION_STATE_CONSUMED
+        consumed_on_incomplete.save(update_fields=['consumption_state'])
+
+        pool = InvoiceWizardService.get_source_pool(self.invoice)
+        mat_atom = self._find_atom(pool, 'material', consumed_on_incomplete.pk)
+        self.assertIsNotNone(mat_atom, 'consumed material must appear in pool')
+        self.assertEqual(mat_atom['state'], 'available')
+
+    def test_append_atoms_rejects_incomplete_task(self):
+        """add_atoms_to_line_item (append path) must also reject a non-complete task."""
+        from django.core.exceptions import ValidationError
+        from apps.invoicing.services import InvoiceWizardService
+
+        # Build an existing draft line item by adding a legitimately-billable atom.
+        existing_li = InvoiceWizardService.add_atoms_to_new_line_item(
+            self.invoice, [{'type': 'task', 'id': self.complete_task.pk}],
+        )
+        with self.assertRaises(ValidationError):
+            InvoiceWizardService.add_atoms_to_line_item(
+                existing_li, [{'type': 'task', 'id': self.incomplete_task.pk}],
+            )
+
+    def test_append_atoms_rejects_unconsumed_material(self):
+        """add_atoms_to_line_item (append path) must also reject an unconsumed material."""
+        from django.core.exceptions import ValidationError
+        from apps.invoicing.services import InvoiceWizardService
+
+        # Build an existing draft line item by adding a legitimately-billable atom.
+        existing_li = InvoiceWizardService.add_atoms_to_new_line_item(
+            self.invoice, [{'type': 'material', 'id': self.consumed_material.pk}],
+        )
+        with self.assertRaises(ValidationError):
+            InvoiceWizardService.add_atoms_to_line_item(
+                existing_li, [{'type': 'material', 'id': self.pending_material.pk}],
+            )

--- a/tests/test_api_invoicing.py
+++ b/tests/test_api_invoicing.py
@@ -1,10 +1,12 @@
+from decimal import Decimal
 from unittest.mock import patch, MagicMock
 from apps.core.models import JobHistory
 from rest_framework.test import APIClient
 from tests.base import BaseTestCase
 from apps.core.models import User, EmailRecord
 from apps.invoicing.models import Invoice, InvoiceLineItem
-from apps.jobs.models import Job
+from apps.jobs.models import Job, RateScheme
+from apps.inventory.models import Material
 
 
 class InvoiceAPITest(BaseTestCase):
@@ -234,3 +236,157 @@ class InvoiceSendTest(BaseTestCase):
             format='json',
         )
         self.assertEqual(response.status_code, 400)
+
+
+class BillabilityGateTest(BaseTestCase):
+    """Task 5: incomplete tasks and unconsumed materials are not billable."""
+
+    def setUp(self):
+        from apps.core.models import AccountingCategory
+        from apps.contacts.models import Contact
+        from apps.jobs.models import Task
+        from apps.inventory.models import InventoryItem
+
+        super().setUp()
+
+        self.contact = Contact.objects.create(
+            first_name='Bill', last_name='Test',
+            email='bill@test.com', mobile_number='555-9999',
+        )
+        self.cat = AccountingCategory.objects.create(name='BillCat', code='BCAT')
+        self.scheme = RateScheme.objects.create(
+            name='Hourly-bill', algorithm=RateScheme.ELAPSED_TIME,
+            rate=Decimal('50.00'), unit_label='hours',
+            accounting_category=self.cat,
+        )
+        self.job = Job.objects.create(
+            contact=self.contact, status=Job.STATUS_APPROVED,
+            job_number='JOB-BILL-001',
+        )
+
+        # An incomplete (pending) task — must appear as not_billable
+        self.incomplete_task = Task.objects.create(
+            job=self.job, name='Pending Work', rate_scheme=self.scheme,
+        )
+        # Status is STATUS_PENDING by default — don't change it.
+
+        # A complete task — for contrast
+        self.complete_task = Task.objects.create(
+            job=self.job, name='Done Work', rate_scheme=self.scheme,
+        )
+        self.complete_task.status = Task.STATUS_COMPLETE
+        self.complete_task.save()
+
+        pli = InventoryItem.objects.create(
+            code='BCAT-PLY', description='Plywood',
+            selling_price=Decimal('10.00'),
+            accounting_category=self.cat,
+        )
+
+        # A pending (unconsumed) material on the incomplete task
+        self.pending_material = Material.objects.create(
+            job=self.job, task=self.incomplete_task,
+            description='Pending Ply', quantity=Decimal('2.00'),
+            sell_price=Decimal('10.00'), inventory_item=pli,
+            accounting_category=self.cat,
+        )
+        # consumption_state is PENDING by default — don't change it.
+
+        # A consumed material (on the complete task) — for contrast.
+        # Set consumption_state directly via update_fields to bypass inventory
+        # on-hand checks in MaterialService.consume (test fixture only).
+        self.consumed_material = Material.objects.create(
+            job=self.job, task=self.complete_task,
+            description='Used Ply', quantity=Decimal('1.00'),
+            sell_price=Decimal('10.00'), inventory_item=pli,
+            accounting_category=self.cat,
+        )
+        self.consumed_material.consumption_state = Material.CONSUMPTION_STATE_CONSUMED
+        self.consumed_material.save(update_fields=['consumption_state'])
+
+        self.invoice = Invoice.objects.create(job=self.job, status=Invoice.STATUS_DRAFT)
+
+    def _find_atom(self, pool, atom_type, atom_id):
+        """Walk pool['tasks'][*]['atoms'] for a matching type+id."""
+        for group in pool['tasks']:
+            for atom in group['atoms']:
+                if atom['type'] == atom_type and atom['id'] == atom_id:
+                    return atom
+        return None
+
+    def test_source_pool_marks_incomplete_task_not_billable(self):
+        from apps.invoicing.services import InvoiceWizardService
+        pool = InvoiceWizardService.get_source_pool(self.invoice)
+        task_atom = self._find_atom(pool, 'task', self.incomplete_task.pk)
+        self.assertIsNotNone(task_atom, 'incomplete task must appear in pool')
+        self.assertEqual(task_atom['state'], 'not_billable')
+        self.assertEqual(task_atom['not_billable_reason'], 'task_incomplete')
+
+    def test_source_pool_marks_pending_material_not_billable(self):
+        from apps.invoicing.services import InvoiceWizardService
+        pool = InvoiceWizardService.get_source_pool(self.invoice)
+        mat_atom = self._find_atom(pool, 'material', self.pending_material.pk)
+        self.assertIsNotNone(mat_atom, 'pending material must appear in pool')
+        self.assertEqual(mat_atom['state'], 'not_billable')
+        self.assertEqual(mat_atom['not_billable_reason'], 'material_unconsumed')
+
+    def test_source_pool_complete_task_available(self):
+        from apps.invoicing.services import InvoiceWizardService
+        pool = InvoiceWizardService.get_source_pool(self.invoice)
+        task_atom = self._find_atom(pool, 'task', self.complete_task.pk)
+        self.assertIsNotNone(task_atom, 'complete task must appear in pool')
+        self.assertEqual(task_atom['state'], 'available')
+
+    def test_source_pool_consumed_material_available(self):
+        from apps.invoicing.services import InvoiceWizardService
+        pool = InvoiceWizardService.get_source_pool(self.invoice)
+        mat_atom = self._find_atom(pool, 'material', self.consumed_material.pk)
+        self.assertIsNotNone(mat_atom, 'consumed material must appear in pool')
+        self.assertEqual(mat_atom['state'], 'available')
+
+    def test_add_atoms_rejects_incomplete_task(self):
+        from django.core.exceptions import ValidationError
+        from apps.invoicing.services import InvoiceWizardService
+        with self.assertRaises(ValidationError):
+            InvoiceWizardService.add_atoms_to_new_line_item(
+                self.invoice, [{'type': 'task', 'id': self.incomplete_task.pk}],
+            )
+
+    def test_add_atoms_rejects_unconsumed_material(self):
+        from django.core.exceptions import ValidationError
+        from apps.invoicing.services import InvoiceWizardService
+        with self.assertRaises(ValidationError):
+            InvoiceWizardService.add_atoms_to_new_line_item(
+                self.invoice, [{'type': 'material', 'id': self.pending_material.pk}],
+            )
+
+    def test_add_atoms_accepts_complete_task(self):
+        from apps.invoicing.services import InvoiceWizardService
+        li = InvoiceWizardService.add_atoms_to_new_line_item(
+            self.invoice, [{'type': 'task', 'id': self.complete_task.pk}],
+        )
+        self.assertIsNotNone(li)
+        self.assertEqual(li.sources.count(), 1)
+
+    def test_add_atoms_accepts_consumed_material(self):
+        from apps.invoicing.services import InvoiceWizardService
+        li = InvoiceWizardService.add_atoms_to_new_line_item(
+            self.invoice, [{'type': 'material', 'id': self.consumed_material.pk}],
+        )
+        self.assertIsNotNone(li)
+        self.assertEqual(li.sources.count(), 1)
+
+    def test_not_billable_atom_dict_has_not_billable_reason_key(self):
+        """Every atom dict carries not_billable_reason — None for available atoms."""
+        from apps.invoicing.services import InvoiceWizardService
+        pool = InvoiceWizardService.get_source_pool(self.invoice)
+        complete_atom = self._find_atom(pool, 'task', self.complete_task.pk)
+        self.assertIn('not_billable_reason', complete_atom)
+        self.assertIsNone(complete_atom['not_billable_reason'])
+
+    def test_incomplete_task_child_material_is_not_billable(self):
+        """Material on an incomplete task is not_billable (unconsumed)."""
+        from apps.invoicing.services import InvoiceWizardService
+        pool = InvoiceWizardService.get_source_pool(self.invoice)
+        mat_atom = self._find_atom(pool, 'material', self.pending_material.pk)
+        self.assertEqual(mat_atom['state'], 'not_billable')

--- a/tests/test_api_job_tasklist.py
+++ b/tests/test_api_job_tasklist.py
@@ -7,9 +7,11 @@ Reorder and add-from-template are tested in test_api_jobs.py against
 
 from decimal import Decimal
 from rest_framework.test import APIClient
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 from apps.core.models import User, AccountingCategory
 from apps.jobs.models import Job, Task, RateScheme
+from apps.jobs.services import TaskService
 from apps.contacts.models import Contact
 from apps.inventory.models import Material, InventoryItem
 
@@ -354,6 +356,18 @@ class TerminalTaskGuardTest(TestCase):
             format='json',
         )
         self.assertEqual(response.status_code, 201)
+
+    def test_update_task_rejects_edit_on_complete_task(self):
+        task = self._make_task(Task.STATUS_COMPLETE)
+        with self.assertRaises(ValidationError):
+            TaskService.update_task(task.pk, name='renamed')
+
+    def test_update_task_allows_sort_order_on_complete_task(self):
+        task = self._make_task(Task.STATUS_COMPLETE)
+        # sort_order is cosmetic; must remain editable
+        TaskService.update_task(task.pk, sort_order=5)
+        task.refresh_from_db()
+        self.assertEqual(task.sort_order, 5)
 
 
 class TaskSerializerFlattenTest(TestCase):

--- a/tests/test_api_job_tasklist.py
+++ b/tests/test_api_job_tasklist.py
@@ -526,3 +526,17 @@ class TaskListInvoiceFieldTest(TestCase):
         resp = self.client.get(f'/api/tasks/{self.task.pk}/subtasks/')
         self.assertEqual(resp.status_code, 200)
         self.assertIsNone(resp.data[0]['invoice'])
+
+    def test_task_retrieve_carries_invoice_ref(self):
+        from apps.invoicing.models import InvoiceLineItemSource
+        inv = self._invoice_atom(InvoiceLineItemSource.SOURCE_TASK, self.task.pk)
+        resp = self.client.get(f'/api/tasks/{self.task.pk}/')
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsNotNone(resp.data['invoice'])
+        self.assertEqual(set(resp.data['invoice'].keys()), {'id', 'number'})
+        self.assertEqual(resp.data['invoice']['id'], inv.pk)
+
+    def test_task_retrieve_invoice_null_when_not_invoiced(self):
+        resp = self.client.get(f'/api/tasks/{self.task.pk}/')
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsNone(resp.data['invoice'])

--- a/tests/test_api_job_tasklist.py
+++ b/tests/test_api_job_tasklist.py
@@ -447,3 +447,82 @@ class TaskSerializerFlattenTest(TestCase):
         self.assertEqual(task.est_qty, Decimal('5.00'))
         self.assertIsNotNone(task.est_worker_time)
         self.assertIsNone(task.actual_qty)
+
+
+class TaskListInvoiceFieldTest(TestCase):
+    """The task-list endpoints (/api/tasks/{id}/materials/ and /subtasks/) must
+    carry the per-atom `invoice` ref so the task-list page can show INVOICED."""
+
+    def setUp(self):
+        from apps.core.models import Configuration, AppState
+        # NumberGenerationService needs these to auto-generate invoice_number.
+        Configuration.objects.get_or_create(
+            key='invoice_number_sequence',
+            defaults={'value': 'INV-{counter:04d}'},
+        )
+        AppState.objects.get_or_create(key='invoice_counter', defaults={'value': '0'})
+
+        self.client = APIClient()
+        self.user = User.objects.create_user(username='tliuser', password='pw')
+        self.client.force_authenticate(user=self.user)
+        self.contact = Contact.objects.create(first_name='T', last_name='L')
+        self.job = Job.objects.create(
+            job_number='TLI-001', name='TLI Job', contact=self.contact,
+        )
+        self.scheme = _make_scheme('tli')
+        self.category = AccountingCategory.objects.create(name='G', code='GTLI')
+        self.task = Task.objects.create(
+            job=self.job, name='Parent', rate_scheme=self.scheme,
+        )
+        self.material = Material.objects.create(
+            job=self.job, task=self.task, description='Slab',
+            quantity=2, unit_cost=Decimal('5.00'), sell_price=Decimal('10.00'),
+            accounting_category=self.category,
+        )
+        self.subtask = Task.objects.create(
+            job=self.job, name='Child', rate_scheme=self.scheme,
+            parent_task=self.task,
+        )
+
+    def _invoice_atom(self, source_type, source_pk):
+        from apps.invoicing.models import (
+            Invoice, InvoiceLineItem, InvoiceLineItemSource,
+        )
+        inv = Invoice.objects.create(job=self.job, status=Invoice.STATUS_DRAFT)
+        li = InvoiceLineItem.objects.create(
+            invoice=inv, description='x', qty=Decimal('1'),
+            units='none', price=Decimal('10.00'),
+        )
+        InvoiceLineItemSource.objects.create(
+            invoice_line_item=li, source_type=source_type, source_pk=source_pk,
+        )
+        return inv
+
+    def test_materials_endpoint_carries_invoice_ref(self):
+        from apps.invoicing.models import InvoiceLineItemSource
+        inv = self._invoice_atom(InvoiceLineItemSource.SOURCE_MATERIAL, self.material.pk)
+        resp = self.client.get(f'/api/tasks/{self.task.pk}/materials/')
+        self.assertEqual(resp.status_code, 200)
+        row = resp.data[0]
+        self.assertIsNotNone(row['invoice'])
+        self.assertEqual(set(row['invoice'].keys()), {'id', 'number'})
+        self.assertEqual(row['invoice']['id'], inv.pk)
+
+    def test_materials_endpoint_invoice_null_when_not_invoiced(self):
+        resp = self.client.get(f'/api/tasks/{self.task.pk}/materials/')
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsNone(resp.data[0]['invoice'])
+
+    def test_subtasks_endpoint_carries_invoice_ref(self):
+        from apps.invoicing.models import InvoiceLineItemSource
+        inv = self._invoice_atom(InvoiceLineItemSource.SOURCE_TASK, self.subtask.pk)
+        resp = self.client.get(f'/api/tasks/{self.task.pk}/subtasks/')
+        self.assertEqual(resp.status_code, 200)
+        row = resp.data[0]
+        self.assertIsNotNone(row['invoice'])
+        self.assertEqual(row['invoice']['id'], inv.pk)
+
+    def test_subtasks_endpoint_invoice_null_when_not_invoiced(self):
+        resp = self.client.get(f'/api/tasks/{self.task.pk}/subtasks/')
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsNone(resp.data[0]['invoice'])

--- a/tests/test_api_jobs.py
+++ b/tests/test_api_jobs.py
@@ -5,14 +5,14 @@ from rest_framework import status
 from django.contrib.auth.models import Permission
 from django.test import TestCase
 from tests.base import BaseTestCase
-from apps.core.models import User, AccountingCategory
+from apps.core.models import User, AccountingCategory, Configuration, AppState
 from apps.contacts.models import Contact
 from apps.jobs.models import Job, Task, PlanTask, RateScheme
 from apps.estimates.models import (
     EstWorksheet, WorkTemplate, TaskTemplate,
     TemplateTaskAssociation,
 )
-from apps.inventory.models import PlanMaterial
+from apps.inventory.models import PlanMaterial, Material
 
 
 def _make_admin(username='admin_jobapi'):
@@ -708,3 +708,141 @@ class JobAddFromTemplateTest(TestCase):
         )
         self.assertIn(response.status_code, [401, 403])
 
+
+class JobDetailInvoiceFieldTest(TestCase):
+    """Task/material atoms nested in GET /api/jobs/{id}/ carry an 'invoice' field."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = _make_admin('invfld_admin')
+        self.client.force_authenticate(user=self.user)
+        self.contact = Contact.objects.create(first_name='T', last_name='C')
+        self.job = Job.objects.create(
+            job_number='INV-F-001', name='Invoice Field Job', contact=self.contact,
+        )
+        ac = AccountingCategory.objects.create(code='INVF-AC', name='invf-ac')
+        # Required for Invoice.save() to generate invoice numbers
+        Configuration.objects.get_or_create(
+            key='invoice_number_sequence',
+            defaults={'value': 'INV-{year}-{counter:04d}'},
+        )
+        AppState.objects.get_or_create(key='invoice_counter', defaults={'value': '0'})
+        self.scheme = RateScheme.objects.create(
+            name='S-invf', algorithm=RateScheme.FLAT_FEE,
+            rate=Decimal('10.00'), unit_label='ea', accounting_category=ac,
+        )
+        self.task = Task.objects.create(
+            job=self.job, name='Invoiceable Task', rate_scheme=self.scheme,
+        )
+        self.material = Material.objects.create(
+            job=self.job,
+            description='Test Material',
+            quantity=Decimal('2.00'),
+            sell_price=Decimal('5.00'),
+            accounting_category=ac,
+        )
+
+    def _invoice_task(self, task):
+        """Create a draft Invoice with a line item sourced from a task."""
+        from apps.invoicing.models import Invoice, InvoiceLineItem, InvoiceLineItemSource
+        inv = Invoice.objects.create(job=task.job, status=Invoice.STATUS_DRAFT)
+        li = InvoiceLineItem.objects.create(
+            invoice=inv, description='t', qty=Decimal('1'),
+            units='none', price=Decimal('10.00'),
+        )
+        InvoiceLineItemSource.objects.create(
+            invoice_line_item=li,
+            source_type=InvoiceLineItemSource.SOURCE_TASK,
+            source_pk=task.pk,
+        )
+        return inv
+
+    def _invoice_material(self, material):
+        """Create a draft Invoice with a line item sourced from a material."""
+        from apps.invoicing.models import Invoice, InvoiceLineItem, InvoiceLineItemSource
+        inv = Invoice.objects.create(job=material.job, status=Invoice.STATUS_DRAFT)
+        li = InvoiceLineItem.objects.create(
+            invoice=inv, description='m', qty=material.quantity,
+            units='none', price=material.sell_price,
+        )
+        InvoiceLineItemSource.objects.create(
+            invoice_line_item=li,
+            source_type=InvoiceLineItemSource.SOURCE_MATERIAL,
+            source_pk=material.pk,
+        )
+        return inv
+
+    def _get_job_detail(self):
+        resp = self.client.get(f'/api/jobs/{self.job.pk}/')
+        self.assertEqual(resp.status_code, 200)
+        return resp.json()
+
+    def test_job_detail_marks_invoiced_task(self):
+        inv = self._invoice_task(self.task)
+        data = self._get_job_detail()
+        task_row = next(t for t in data['tasks'] if t['task_id'] == self.task.pk)
+        self.assertIsNotNone(task_row['invoice'])
+        self.assertEqual(set(task_row['invoice'].keys()), {'id', 'number'})
+        self.assertEqual(task_row['invoice']['id'], inv.pk)
+
+    def test_job_detail_uninvoiced_task_has_null_invoice(self):
+        data = self._get_job_detail()
+        task_row = next(t for t in data['tasks'] if t['task_id'] == self.task.pk)
+        self.assertIsNone(task_row['invoice'])
+
+    def test_job_detail_marks_invoiced_material(self):
+        inv = self._invoice_material(self.material)
+        data = self._get_job_detail()
+        mat_row = next(m for m in data['materials'] if m['material_id'] == self.material.pk)
+        self.assertIsNotNone(mat_row['invoice'])
+        self.assertEqual(set(mat_row['invoice'].keys()), {'id', 'number'})
+        self.assertEqual(mat_row['invoice']['id'], inv.pk)
+
+    def test_job_detail_uninvoiced_material_has_null_invoice(self):
+        data = self._get_job_detail()
+        mat_row = next(m for m in data['materials'] if m['material_id'] == self.material.pk)
+        self.assertIsNone(mat_row['invoice'])
+
+    def test_job_detail_invoice_claims_single_query(self):
+        """Claims are built in one query regardless of how many invoiced atoms the job has.
+
+        Empirically derived: run once without the second atom to pin the baseline,
+        then assert adding a second invoiced atom does NOT increase the count.
+        """
+        from apps.invoicing.models import Invoice, InvoiceLineItem, InvoiceLineItemSource
+        from django.test.utils import CaptureQueriesContext
+        from django.db import connection
+
+        # Create one invoice with a task source (one invoiced atom)
+        inv = self._invoice_task(self.task)
+
+        # Measure baseline with one invoiced task
+        with CaptureQueriesContext(connection) as ctx_one:
+            resp = self.client.get(f'/api/jobs/{self.job.pk}/')
+        self.assertEqual(resp.status_code, 200)
+        count_one = len(ctx_one.captured_queries)
+
+        # Add a second invoiced atom to the same invoice (material) — same job,
+        # same invoice avoids the one-draft-per-job constraint.
+        li2 = InvoiceLineItem.objects.create(
+            invoice=inv, description='m2', qty=self.material.quantity,
+            units='none', price=self.material.sell_price,
+        )
+        InvoiceLineItemSource.objects.create(
+            invoice_line_item=li2,
+            source_type=InvoiceLineItemSource.SOURCE_MATERIAL,
+            source_pk=self.material.pk,
+        )
+
+        with CaptureQueriesContext(connection) as ctx_two:
+            resp = self.client.get(f'/api/jobs/{self.job.pk}/')
+        self.assertEqual(resp.status_code, 200)
+        count_two = len(ctx_two.captured_queries)
+
+        # The claim map is built once per job — adding a second invoiced atom
+        # must not fire an extra query.
+        self.assertEqual(
+            count_one, count_two,
+            f'Query count grew when a second invoiced atom was added: '
+            f'1 atom → {count_one} queries, 2 atoms → {count_two} queries',
+        )

--- a/tests/test_api_jobs.py
+++ b/tests/test_api_jobs.py
@@ -846,3 +846,14 @@ class JobDetailInvoiceFieldTest(TestCase):
             f'Query count grew when a second invoiced atom was added: '
             f'1 atom → {count_one} queries, 2 atoms → {count_two} queries',
         )
+
+        # Absolute pin: guard against flat per-request regressions that the
+        # comparative assertion above cannot catch.  N=13 was derived empirically
+        # (run with N=1, read the failure message).  If the jobs viewset gains new
+        # prefetches/annotations this number may need updating — update it together
+        # with a comment explaining why the count changed.
+        self.assertEqual(
+            count_one, 13,
+            f'Absolute query count for job-detail changed: expected 13, got {count_one}. '
+            f'Update this pin if the viewset legitimately changed (add a comment explaining why).',
+        )

--- a/tests/test_api_materials.py
+++ b/tests/test_api_materials.py
@@ -271,3 +271,89 @@ class MaterialApiPermissionTest(APITestCase):
         }, format='json')
         self.assertIn(resp.status_code, [401, 403],
                       f'Expected 401 or 403, got {resp.status_code}')
+
+
+class MaterialInvoicedFreezeTest(APITestCase):
+    """Task 4: sell_price and unconsume are blocked on an invoiced material."""
+
+    def setUp(self):
+        from apps.core.models import Configuration, AppState
+        # NumberGenerationService needs these to auto-generate invoice_number.
+        Configuration.objects.get_or_create(
+            key='invoice_number_sequence',
+            defaults={'value': 'INV-{year}-{counter:04d}'},
+        )
+        AppState.objects.get_or_create(key='invoice_counter', defaults={'value': '0'})
+
+        self.cat = AccountingCategory.objects.create(name='c', code='MFRZ1')
+        self.user = User.objects.create_user('mfrz_u', password='p')
+        self.client.force_login(self.user)
+        contact = Contact.objects.create(first_name='C', last_name='T')
+        biz = Business.objects.create(business_name='B', default_contact=contact)
+        contact.business = biz
+        contact.save()
+        self.job = Job.objects.create(job_number='JOB-FRZ-1', contact=contact)
+        self.pli = InventoryItem.objects.create(
+            code='I-FRZ', accounting_category=self.cat, is_catalog=True,
+            qty_on_hand=Decimal('10'),
+        )
+
+    def _make_consumed_material(self):
+        """PLI-linked consumed material."""
+        from apps.inventory.services import MaterialService
+        m = MaterialService.create_on_job(
+            job=self.job, task=None, description='pli mat',
+            quantity=Decimal('2'), inventory_item=self.pli,
+        )
+        MaterialService.consume(m)
+        return m
+
+    def _make_consumed_freeform_material(self):
+        """Freeform (no inventory_item) consumed material."""
+        from apps.inventory.services import MaterialService
+        m = MaterialService.create_on_job(
+            job=self.job, task=None, description='freeform mat',
+            quantity=Decimal('1'), inventory_item=None,
+            accounting_category=self.cat,
+        )
+        MaterialService.consume(m)
+        return m
+
+    def _invoice_material(self, material):
+        """Create a draft Invoice with a line item sourced from material."""
+        from apps.invoicing.models import Invoice, InvoiceLineItem, InvoiceLineItemSource
+        inv = Invoice.objects.create(job=material.job, status=Invoice.STATUS_DRAFT)
+        li = InvoiceLineItem.objects.create(
+            invoice=inv, description='m', qty=material.quantity,
+            units='none', price=material.sell_price,
+        )
+        InvoiceLineItemSource.objects.create(
+            invoice_line_item=li,
+            source_type=InvoiceLineItemSource.SOURCE_MATERIAL,
+            source_pk=material.pk,
+        )
+
+    def test_update_pricing_blocks_sell_price_when_invoiced(self):
+        from django.core.exceptions import ValidationError
+        from apps.inventory.services import MaterialService
+        mat = self._make_consumed_material()
+        self._invoice_material(mat)
+        with self.assertRaises(ValidationError):
+            MaterialService.update_pricing(mat, sell_price=Decimal('99.00'))
+
+    def test_unconsume_blocked_when_invoiced(self):
+        from django.core.exceptions import ValidationError
+        from apps.inventory.services import MaterialService
+        mat = self._make_consumed_material()
+        self._invoice_material(mat)
+        with self.assertRaises(ValidationError):
+            MaterialService.unconsume(mat)
+
+    def test_patch_sell_price_blocked_on_invoiced_freeform_material(self):
+        mat = self._make_consumed_freeform_material()
+        self._invoice_material(mat)
+        resp = self.client.patch(
+            f'/api/materials/{mat.pk}/', {'sell_price': '77.00'},
+            content_type='application/json',
+        )
+        self.assertEqual(resp.status_code, 400)

--- a/tests/test_api_materials.py
+++ b/tests/test_api_materials.py
@@ -357,3 +357,19 @@ class MaterialInvoicedFreezeTest(APITestCase):
             content_type='application/json',
         )
         self.assertEqual(resp.status_code, 400)
+
+    def test_patch_sell_price_blocked_on_invoiced_pli_material(self):
+        """API-level coverage for the PLI-linked branch in MaterialViewSet.partial_update.
+
+        The view routes PLI-linked pricing PATCHes through MaterialService.update_pricing
+        (apps/api/inventory/views.py ~135-148) and converts the resulting
+        ValidationError to 400.  Without that guard, the PATCH would succeed (200)
+        because the PLI branch skips the freeform sell_price check entirely.
+        """
+        mat = self._make_consumed_material()
+        self._invoice_material(mat)
+        resp = self.client.patch(
+            f'/api/materials/{mat.pk}/', {'sell_price': '99.00'},
+            content_type='application/json',
+        )
+        self.assertEqual(resp.status_code, 400)

--- a/tests/test_invoice_claims.py
+++ b/tests/test_invoice_claims.py
@@ -1,0 +1,51 @@
+from decimal import Decimal
+from tests.base import BaseTestCase
+from apps.invoicing.claims import InvoiceClaimService
+from apps.invoicing.models import Invoice, InvoiceLineItem, InvoiceLineItemSource
+from apps.jobs.models import Job
+
+
+class InvoiceClaimServiceTest(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.job = Job.objects.first()
+
+    def _make_invoice_line_with_source(self, job, source_type, source_pk, status):
+        inv = Invoice.objects.create(job=job, status=status)
+        li = InvoiceLineItem.objects.create(
+            invoice=inv, description='x', qty=Decimal('1'),
+            units='none', price=Decimal('5.00'),
+        )
+        InvoiceLineItemSource.objects.create(
+            invoice_line_item=li, source_type=source_type, source_pk=source_pk,
+        )
+        return inv
+
+    def test_is_invoiced_true_for_live_source(self):
+        self._make_invoice_line_with_source(
+            self.job, InvoiceLineItemSource.SOURCE_TASK, 4242, Invoice.STATUS_DRAFT,
+        )
+        self.assertTrue(
+            InvoiceClaimService.is_invoiced(InvoiceLineItemSource.SOURCE_TASK, 4242)
+        )
+
+    def test_is_invoiced_false_when_only_cancelled(self):
+        self._make_invoice_line_with_source(
+            self.job, InvoiceLineItemSource.SOURCE_TASK, 4243, Invoice.STATUS_CANCELLED,
+        )
+        self.assertFalse(
+            InvoiceClaimService.is_invoiced(InvoiceLineItemSource.SOURCE_TASK, 4243)
+        )
+
+    def test_claims_for_job_keys_and_excludes_cancelled(self):
+        self._make_invoice_line_with_source(
+            self.job, InvoiceLineItemSource.SOURCE_MATERIAL, 11, Invoice.STATUS_DRAFT,
+        )
+        self._make_invoice_line_with_source(
+            self.job, InvoiceLineItemSource.SOURCE_TASK, 22, Invoice.STATUS_CANCELLED,
+        )
+        claims = InvoiceClaimService.claims_for_job(self.job)
+        self.assertIn((InvoiceLineItemSource.SOURCE_MATERIAL, 11), claims)
+        self.assertNotIn((InvoiceLineItemSource.SOURCE_TASK, 22), claims)
+        ref = claims[(InvoiceLineItemSource.SOURCE_MATERIAL, 11)]
+        self.assertEqual(set(ref.keys()), {'invoice_id', 'invoice_number'})

--- a/tests/test_invoice_wizard_api.py
+++ b/tests/test_invoice_wizard_api.py
@@ -124,6 +124,9 @@ class SourcePoolEndpointTest(TestCase):
         self.blep = Blep.objects.create(
             task=self.task, user=self.user, start_time=start, end_time=start + timezone.timedelta(hours=2),
         )
+        # Complete the task so it is billable (Task 5: only complete tasks are billable).
+        self.task.status = Task.STATUS_COMPLETE
+        self.task.save()
         self.invoice = Invoice.objects.create(job=self.job, status=Invoice.STATUS_DRAFT)
 
     def test_returns_tree_shape(self):
@@ -186,6 +189,9 @@ class LineItemsFromAtomsEndpointTest(TestCase):
         self.blep = Blep.objects.create(
             task=self.task, user=self.user, start_time=start, end_time=start + timezone.timedelta(hours=2),
         )
+        # Complete the task so it is billable (Task 5: only complete tasks are billable).
+        self.task.status = Task.STATUS_COMPLETE
+        self.task.save()
         self.invoice = Invoice.objects.create(job=self.job, status=Invoice.STATUS_DRAFT)
 
     def test_creates_line_item_with_sources(self):
@@ -280,6 +286,11 @@ class AddAtomsEndpointTest(TestCase):
             start_time=start + timezone.timedelta(hours=3),
             end_time=start + timezone.timedelta(hours=4),
         )
+        # Complete tasks so they are billable (Task 5: only complete tasks are billable).
+        self.task.status = Task.STATUS_COMPLETE
+        self.task.save()
+        self.task2.status = Task.STATUS_COMPLETE
+        self.task2.save()
         self.invoice = Invoice.objects.create(job=self.job, status=Invoice.STATUS_DRAFT)
 
         from apps.invoicing.services import InvoiceWizardService
@@ -357,6 +368,11 @@ class RemoveAtomsEndpointTest(TestCase):
             start_time=start + timezone.timedelta(hours=3),
             end_time=start + timezone.timedelta(hours=4),
         )
+        # Complete tasks so they are billable (Task 5: only complete tasks are billable).
+        self.task1.status = Task.STATUS_COMPLETE
+        self.task1.save()
+        self.task2.status = Task.STATUS_COMPLETE
+        self.task2.save()
         self.invoice = Invoice.objects.create(job=self.job, status=Invoice.STATUS_DRAFT)
 
         from apps.invoicing.services import InvoiceWizardService

--- a/tests/test_invoice_wizard_service.py
+++ b/tests/test_invoice_wizard_service.py
@@ -119,10 +119,16 @@ class GetSourcePoolTest(TestCase):
         self.task_billable = Task.objects.create(
             job=self.job, name='Site demo', rate_scheme=self.scheme,
         )
+        # Complete the task so it is billable (Task 5: only complete tasks are billable).
+        self.task_billable.status = Task.STATUS_COMPLETE
+        self.task_billable.save()
 
         self.task_empty = Task.objects.create(
             job=self.job, name='Inspection', rate_scheme=self.scheme,
         )
+        # Complete the task so it is billable.
+        self.task_empty.status = Task.STATUS_COMPLETE
+        self.task_empty.save()
 
         self.task_cancelled = Task.objects.create(
             job=self.job, name='Cancelled work', rate_scheme=self.scheme,
@@ -159,6 +165,9 @@ class GetSourcePoolTest(TestCase):
             inventory_item=self.pli,
             accounting_category=self.category,
         )
+        # Consume the material so it is billable (Task 5: only consumed materials are billable).
+        self.material.consumption_state = Material.CONSUMPTION_STATE_CONSUMED
+        self.material.save(update_fields=['consumption_state'])
 
         self.invoice = Invoice.objects.create(job=self.job, status=Invoice.STATUS_DRAFT)
 
@@ -320,6 +329,12 @@ class AddAtomsToNewLineItemTest(TestCase):
             start_time=start + timezone.timedelta(hours=5),
             end_time=start + timezone.timedelta(hours=6),
         )
+        # Complete tasks so they are billable (Task 5: only complete tasks are billable).
+        self.task.status = Task.STATUS_COMPLETE
+        self.task.save()
+        self.task2.status = Task.STATUS_COMPLETE
+        self.task2.save()
+
         self.pli = InventoryItem.objects.create(
             code='PLY', description='Plywood',
             selling_price=Decimal('25.00'),
@@ -330,6 +345,10 @@ class AddAtomsToNewLineItemTest(TestCase):
             quantity=Decimal('1.00'), sell_price=Decimal('25.00'),
             inventory_item=self.pli, accounting_category=self.cat_materials,
         )
+        # Consume the material so it is billable (Task 5: only consumed materials are billable).
+        self.material.consumption_state = Material.CONSUMPTION_STATE_CONSUMED
+        self.material.save(update_fields=['consumption_state'])
+
         self.invoice = Invoice.objects.create(job=self.job, status=Invoice.STATUS_DRAFT)
 
     def test_creates_line_item_and_sources(self):
@@ -376,6 +395,9 @@ class AddAtomsToNewLineItemTest(TestCase):
             quantity=Decimal('3.00'), sell_price=Decimal('5.00'),
             accounting_category=self.cat_materials,
         )
+        # Consume the material so it is billable (Task 5: only consumed materials are billable).
+        mat3.consumption_state = Material.CONSUMPTION_STATE_CONSUMED
+        mat3.save(update_fields=['consumption_state'])
         atoms = [{'type': 'material', 'id': mat3.pk}]
         line_item = InvoiceWizardService.add_atoms_to_new_line_item(self.invoice, atoms)
         self.assertEqual(line_item.qty, Decimal('3.00'))
@@ -521,6 +543,12 @@ class AddAtomsToExistingLineItemTest(TestCase):
             start_time=start + timezone.timedelta(hours=3),
             end_time=start + timezone.timedelta(hours=4),
         )
+        # Complete tasks so they are billable (Task 5: only complete tasks are billable).
+        self.task.status = Task.STATUS_COMPLETE
+        self.task.save()
+        self.task2.status = Task.STATUS_COMPLETE
+        self.task2.save()
+
         self.invoice = Invoice.objects.create(job=self.job, status=Invoice.STATUS_DRAFT)
 
         # Start with one atom on the line item — task atom for task1.
@@ -641,6 +669,11 @@ class RemoveAtomsFromLineItemTest(TestCase):
             start_time=start + timezone.timedelta(hours=4, minutes=30),
             end_time=start + timezone.timedelta(hours=6),
         )
+        # Complete all tasks so they are billable (Task 5: only complete tasks are billable).
+        for t in (self.task1, self.task2, self.task3):
+            t.status = Task.STATUS_COMPLETE
+            t.save()
+
         self.invoice = Invoice.objects.create(job=self.job, status=Invoice.STATUS_DRAFT)
 
         self.line_item = InvoiceWizardService.add_atoms_to_new_line_item(
@@ -782,6 +815,11 @@ class RemoveAtomsFromLineItemTest(TestCase):
             start_time=start + timezone.timedelta(hours=2),
             end_time=start + timezone.timedelta(hours=3),
         )
+        # Complete tasks so they are billable (Task 5: only complete tasks are billable).
+        task4.status = Task.STATUS_COMPLETE
+        task4.save()
+        task5.status = Task.STATUS_COMPLETE
+        task5.save()
         li2 = InvoiceWizardService.add_atoms_to_new_line_item(
             self.invoice, [{'type': 'task', 'id': task4.pk}],
         )
@@ -831,6 +869,9 @@ class DiscardDraftTest(TestCase):
         self.blep = Blep.objects.create(
             task=self.task, user=self.user, start_time=start, end_time=start + timezone.timedelta(hours=2),
         )
+        # Complete the task so it is billable (Task 5: only complete tasks are billable).
+        self.task.status = Task.STATUS_COMPLETE
+        self.task.save()
         self.invoice = Invoice.objects.create(job=self.job, status=Invoice.STATUS_DRAFT)
         # Claim the per-task atom directly (atom helper migration is A17)
         self.line_item = InvoiceLineItem.objects.create(
@@ -1049,11 +1090,17 @@ class AddAtomsToNewLineItemDescriptionTest(TestCase):
             start_time=now - timezone.timedelta(hours=1),
             end_time=now,
         )
+        # Complete the task so it is billable (Task 5: only complete tasks are billable).
+        self.task.status = Task.STATUS_COMPLETE
+        self.task.save()
         self.material = Material.objects.create(
             job=self.job, description='Acrylic 1/4"',
             quantity=Decimal('1'), unit_cost=Decimal('20'),
             sell_price=Decimal('40'), accounting_category=self.cat,
         )
+        # Consume the material so it is billable (Task 5: only consumed materials are billable).
+        self.material.consumption_state = Material.CONSUMPTION_STATE_CONSUMED
+        self.material.save(update_fields=['consumption_state'])
 
     def test_single_task_atom_seeds_description_from_name(self):
         atoms = [{'type': 'task', 'id': self.task.pk}]

--- a/tests/test_wizard_bundle_summary.py
+++ b/tests/test_wizard_bundle_summary.py
@@ -52,11 +52,15 @@ class InvoiceWizardBundleSummaryTest(TestCase):
         )
 
     def _task(self, scheme, actual_qty, modifiers=None):
-        return Task.objects.create(
+        t = Task.objects.create(
             job=self.job, name='T', rate_scheme=scheme,
             actual_qty=Decimal(str(actual_qty)),
             active_modifiers=modifiers or [],
         )
+        # Complete the task so it is billable (Task 5: only complete tasks are billable).
+        t.status = Task.STATUS_COMPLETE
+        t.save()
+        return t
 
     def _bundle(self, *tasks):
         atoms = [{'type': 'task', 'id': t.pk} for t in tasks]
@@ -92,6 +96,11 @@ class InvoiceWizardBundleSummaryTest(TestCase):
         start = timezone.now()
         Blep.objects.create(task=a, user=self.user, start_time=start, end_time=start + timedelta(hours=2))
         Blep.objects.create(task=b, user=self.user, start_time=start, end_time=start + timedelta(hours=3))
+        # Complete tasks so they are billable (Task 5: only complete tasks are billable).
+        a.status = Task.STATUS_COMPLETE
+        a.save()
+        b.status = Task.STATUS_COMPLETE
+        b.save()
         li = self._bundle(a, b)
         self.assertEqual(li.units, 'hours')
         self.assertEqual(li.qty, Decimal('5.00'))  # 2h + 3h from Bleps, not 1
@@ -120,6 +129,9 @@ class InvoiceWizardBundleSummaryTest(TestCase):
             quantity=Decimal('1.00'), sell_price=Decimal('5.00'),
             accounting_category=self.cat_mat,
         )
+        # Consume the material so it is billable (Task 5: only consumed materials are billable).
+        mat.consumption_state = Material.CONSUMPTION_STATE_CONSUMED
+        mat.save(update_fields=['consumption_state'])
         atoms = [{'type': 'task', 'id': a.pk}, {'type': 'material', 'id': mat.pk}]
         li = InvoiceWizardService.add_atoms_to_new_line_item(self.invoice, atoms)
         self.assertEqual(li.units, 'none')
@@ -142,6 +154,9 @@ class InvoiceWizardBundleSummaryTest(TestCase):
             quantity=Decimal('1'), sell_price=Decimal('5.00'),
             accounting_category=self.cat_mat,
         )
+        # Consume the material so it is billable (Task 5: only consumed materials are billable).
+        mat.consumption_state = Material.CONSUMPTION_STATE_CONSUMED
+        mat.save(update_fields=['consumption_state'])
         InvoiceWizardService.add_atoms_to_line_item(
             li, [{'type': 'material', 'id': mat.pk}],
         )


### PR DESCRIPTION
Added sensible adjustments to when the various atom types (Tasks, Materials, Expenses) are allowed to be copied to an invoice; also freeze editing once they have been invoiced.  Displaying that an atom is invoiced, and a link to it, in the job overview.  They also get this in the task list, and Tasks have it on their individual pages.